### PR TITLE
Correction in the request example for HEAD /db/doc

### DIFF
--- a/src/api/document/common.rst
+++ b/src/api/document/common.rst
@@ -46,7 +46,7 @@
 
   .. code-block:: http
 
-    GET /db/SpaghettiWithMeatballs HTTP/1.1
+    HEAD /db/SpaghettiWithMeatballs HTTP/1.1
     Accept: application/json
     Host: localhost:5984
 


### PR DESCRIPTION
The request example for `HEAD /db/doc` is using the wrong HTTP method. I also don't think `HEAD` requests should include the `Accept` header (but I might be wrong on this).
