### PR TITLE
Add a missing function source argument to the list of arguments for the ...

### DIFF
--- a/src/query-server/protocol.rst
+++ b/src/query-server/protocol.rst
@@ -227,13 +227,15 @@ keys and the list of values.
 ============
 
 :Command: ``rereduce``
-:Arguments: List of values.
+:Arguments: 
+  - Reduce function source
+  - List of values
 
 When building a view, CouchDB will apply the reduce step directly to the output
 of the map step and the rereduce step to the output of a previous reduce step.
 
-CouchDB will send a list of values, with no keys or document ids, to the
-rereduce step.
+CouchDB will send a list of reduce functions and a list of values, with no keys or
+document ids, to the rereduce step.
 
 CouchDB sends::
 


### PR DESCRIPTION
...rereduce message of the Query Server Protocol

It seems the rereduce message description text had the reduce function source argument missing. The example below was apparently still correct.