### PR TITLE
COUCHDB-2794: Docs not fully correct for couch_httpd_auth/secret

### DIFF
--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -212,7 +212,7 @@ Authentication Configuration
             [couch_httpd_auth]
             require_valid_user = false
 
-    .. config:option:: secret :: Proxy Auth secret token
+    .. config:option:: secret :: Authentication with secret token
 
         The secret token is used for :ref:`api/auth/proxy` and for :ref:`api/auth/cookie`. ::
 

--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -214,7 +214,7 @@ Authentication Configuration
 
     .. config:option:: secret :: Proxy Auth secret token
 
-        The secret token used for :ref:`api/auth/proxy` method. ::
+        The secret token is used for :ref:`api/auth/proxy` and for :ref:`api/auth/cookie`. ::
 
             [couch_httpd_auth]
             secret = 92de07df7e7a3fe14808cef90a7cc0d91


### PR DESCRIPTION
rewording and added also the link to Cookie Auth section.