### PR TITLE
Fix bashism in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,7 @@ PAPERSIZE    := -D latex_paper_size=a4
 SPHINXFLAGS  := -a -W -n -A local=1 $(PAPERSIZE) -d $(BUILDDIR)/doctree
 SPHINXOPTS   := $(SPHINXFLAGS) $(SOURCE)
 
-ENSURECMD=\
-if [[ $(shell which $(1) > /dev/null 2>&1; echo $$?) -eq 1 ]]; then \
-  echo "*** Make sure that $(1) is installed and on your path" && exit 1; \
-fi
+ENSURECMD=which $(1) || (echo "*** Make sure that $(1) is installed and on your path" && exit 1)
 
 
 all: html pdf info man

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PAPERSIZE    := -D latex_paper_size=a4
 SPHINXFLAGS  := -a -W -n -A local=1 $(PAPERSIZE) -d $(BUILDDIR)/doctree
 SPHINXOPTS   := $(SPHINXFLAGS) $(SOURCE)
 
-ENSURECMD=which $(1) || (echo "*** Make sure that $(1) is installed and on your path" && exit 1)
+ENSURECMD=which $(1) /dev/null 2>&1 || (echo "*** Make sure that $(1) is installed and on your path" && exit 1)
 
 
 all: html pdf info man


### PR DESCRIPTION
The [[ operator is a bashism, and fails with POSIX shells (such as dash), replace it with a simplier version that does the same thing, without the unnecessary $(shell) nesting