### PR TITLE
suppress verbose LaTeX output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ latex: $(TEX)
 	$(SPHINXBUILD) -b $@ $(SPHINXOPTS) $(BUILDDIR)/$@
 
 pdf: latex $(PDFLATEX)
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	$(MAKE) LATEXOPTS=' -interaction=batchmode ' -C $(BUILDDIR)/latex all-pdf
 
 info: $(SPHINXBUILD) $(MAKEINFO)
 	$(SPHINXBUILD) -b texinfo $(SPHINXOPTS) $(BUILDDIR)/texinfo


### PR DESCRIPTION
pdflatex CouchDB.tex writes about 700 lines of log output to stdout,
which clutter the output of make when building CouchDB without adding a
lot of value. The option interaction=batchmode reduces this to 3 lines.
The full log of pdflatex is still available in
build/latex/CouchDB.log.