### PR TITLE
ignore build directory instead of _build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 ext/*.pyc
-_build/
+build/
 


### PR DESCRIPTION
`_build` was ignored but the build process actually creates a `build` directory (without leading underscore).