### PR TITLE
Fix the build, and fix the location of the docs repo in the 'Contributing' section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install -yqq texinfo
 
 install:
-  - pip install sphinx==1.3.4
+  - pip install sphinx
 
 script:
   - make ${TARGET}

--- a/src/api/basics.rst
+++ b/src/api/basics.rst
@@ -141,7 +141,7 @@ Request Headers
 
   The returned headers are:
 
-  .. code-block:: http
+  .. code-block:: none
 
       Server: CouchDB (Erlang/OTP)
       Date: Thu, 13 Jan 2011 13:39:34 GMT
@@ -163,7 +163,7 @@ Request Headers
 
   The headers returned include the ``application/json`` content type:
 
-  .. code-block:: http
+  .. code-block:: none
 
       Server: CouchDB (Erlang/OTP)
       Date: Thu, 13 Jan 2013 13:40:11 GMT
@@ -364,7 +364,9 @@ actually "losing" data if you don't accept that numbers are stored in doubles).
 Here's a log for a couple of the more common JSON libraries that happen to be
 on the author's machine:
 
-Ejson (CouchDB's current parser) at CouchDB sha 168a663b::
+Ejson (CouchDB's current parser) at CouchDB sha 168a663b:
+
+.. code-block:: none
 
     $ ./utils/run -i
     Erlang R14B04 (erts-5.8.5) [source] [64-bit] [smp:2:2] [rq:2]
@@ -378,7 +380,9 @@ Ejson (CouchDB's current parser) at CouchDB sha 168a663b::
     3> ejson:encode(ejson:decode(F)).
     <<"1.0123456789012346135">>
 
-Node::
+Node:
+
+.. code-block:: none
 
     $ node -v
     v0.6.15
@@ -390,7 +394,9 @@ Node::
     JSON.stringify(JSON.parse(f))
     '1.0123456789012346'
 
-Python::
+Python:
+
+.. code-block:: none
 
     $ python
     Python 2.7.2 (default, Jun 20 2012, 16:23:33)
@@ -403,7 +409,9 @@ Python::
     json.dumps(json.loads(f))
     '1.0123456789012346'
 
-Ruby::
+Ruby:
+
+.. code-block:: none
 
     $ irb --version
     irb 0.9.5(05/04/13)
@@ -421,7 +429,9 @@ Ruby::
     wrapped the value. Should be obvious it doesn't affect the result of
     parsing the number though.
 
-Spidermonkey::
+Spidermonkey:
+
+.. code-block:: none
 
     $ js -h 2>&1 | head -n 1
     JavaScript-C 1.8.5 2011-03-31
@@ -448,7 +458,9 @@ different, the bytes in a JSON serialized number are chosen such that they
 refer to a single specific value that a double can represent.
 
 The important point to understand is that we're mapping from one infinite set
-onto a finite set. An easy way to see this is by reflecting on this::
+onto a finite set. An easy way to see this is by reflecting on this:
+
+.. code-block:: none
 
     1.0 == 1.00 == 1.000 = 1.(infinite zeroes)
 

--- a/src/api/database/changes.rst
+++ b/src/api/database/changes.rst
@@ -241,7 +241,9 @@ Changes Feeds
 Polling
 -------
 
-By default all changes are immediately returned within the JSON body::
+By default all changes are immediately returned within the JSON body:
+
+.. code-block:: none
 
     GET /somedatabase/_changes HTTP/1.1
 
@@ -265,7 +267,9 @@ individually to make sure.)
 will always be the same as the seq of the last item in results.)
 
 Sending a ``since`` param in the query string skips all changes up to and
-including the given sequence number::
+including the given sequence number:
+
+.. code-block:: none
 
     GET /somedatabase/_changes?since=3 HTTP/1.1
 
@@ -431,7 +435,7 @@ as for replication filters. You specify the name of the filter function
 to the ``filter`` parameter, specifying the design document name and
 :ref:`filter name <filterfun>`. For example:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /db/_changes?filter=design_doc/filtername
 

--- a/src/api/database/index.rst
+++ b/src/api/database/index.rst
@@ -24,13 +24,13 @@ should be the database name that you wish to perform the operation on.
 For example, to obtain the meta information for the database
 ``recipes``, you would use the HTTP request:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /recipes
 
 For clarity, the form below is used in the URL paths:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /db
 

--- a/src/api/ddoc/render.rst
+++ b/src/api/ddoc/render.rst
@@ -304,7 +304,7 @@
 
     **Request**:
 
-    .. code-block:: http
+    .. code-block:: none
 
         POST /recipes/_design/recipe/_update/ingredients HTTP/1.1
         Accept: application/json
@@ -369,7 +369,7 @@
 
     **Request**:
 
-    .. code-block:: http
+    .. code-block:: none
 
         POST /recipes/_design/recipe/_update/ingredients/SpaghettiWithMeatballs HTTP/1.1
         Accept: application/json

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -579,7 +579,7 @@ Sorting order and startkey/endkey
 The sorting direction is applied before the filtering applied using the
 ``startkey`` and ``endkey`` query arguments. For example the following query:
 
-.. code-block:: http
+.. code-block:: none
 
     GET http://couchdb:5984/recipes/_design/recipes/_view/by_ingredient?startkey=%22carrots%22&endkey=%22egg%22
     Accept: application/json

--- a/src/api/document/common.rst
+++ b/src/api/document/common.rst
@@ -359,7 +359,7 @@
 
     **Request**:
 
-    .. code-block:: http
+    .. code-block:: none
 
         COPY /recipes/SpaghettiWithMeatballs HTTP/1.1
         Accept: application/json
@@ -1131,7 +1131,7 @@ or :header:`If-Match`:
 
 **Request**:
 
-.. code-block:: http
+.. code-block:: none
 
     COPY /recipes/SpaghettiWithMeatballs HTTP/1.1
     Accept: application/json
@@ -1167,7 +1167,7 @@ for the target document by appending the ``rev`` parameter to the
 
 **Request**:
 
-.. code-block:: http
+.. code-block:: none
 
     COPY /recipes/SpaghettiWithMeatballs?rev=8-6f5ad8db0f34af24a6e0984cd1a6cfb9 HTTP/1.1
     Accept: application/json

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -365,7 +365,7 @@ If you want to pick out specific parts of the log information you can use the
 and ``offset``, which specifies where the reading of the log should start,
 counted back from the end. For example, if you use the following request:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /_log?bytes=500&offset=2000
 
@@ -549,7 +549,7 @@ For example, to request replication between a database local to the CouchDB
 instance to which you send the request, and a remote database you might use the
 following request:
 
-.. code-block:: http
+.. code-block:: none
 
     POST http://couchdb:5984/_replicate
     Content-Type: application/json
@@ -574,7 +574,7 @@ JSON object:
 You can create the target database (providing your user credentials allow it)
 by adding the ``create_target`` field to the request object:
 
-.. code-block:: http
+.. code-block:: none
 
     POST http://couchdb:5984/_replicate
     Content-Type: application/json
@@ -598,7 +598,7 @@ synchronizes the two databases together. For example, you can request a single
 synchronization between two databases by supplying the ``source`` and
 ``target`` fields within the request JSON content.
 
-.. code-block:: http
+.. code-block:: none
 
     POST http://couchdb:5984/_replicate
     Accept: application/json
@@ -649,7 +649,7 @@ With continuous replication changes in the source database are replicated to
 the target database in perpetuity until you specifically request that
 replication ceases.
 
-.. code-block:: http
+.. code-block:: none
 
     POST http://couchdb:5984/_replicate
     Accept: application/json
@@ -680,7 +680,7 @@ cancellation request must also contain the ``continuous`` field.
 
 For example, the replication request:
 
-.. code-block:: http
+.. code-block:: none
 
     POST http://couchdb:5984/_replicate
     Content-Type: application/json
@@ -695,7 +695,7 @@ For example, the replication request:
 
 Must be canceled using the request:
 
-.. code-block:: http
+.. code-block:: none
 
     POST http://couchdb:5984/_replicate
     Accept: application/json
@@ -919,7 +919,7 @@ You can also access individual statistics by quoting the statistics sections
 and statistic ID as part of the URL path. For example, to get the
 ``request_time`` statistics, you can use:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /_stats/couchdb/request_time
 
@@ -1031,7 +1031,7 @@ The UUID type may be changed at any time through the
 :ref:`Configuration API <api/config/section/key>`. For example, the UUID type
 could be changed to ``random`` by sending this HTTP request:
 
-.. code-block:: http
+.. code-block:: none
 
     PUT http://couchdb:5984/_config/uuids/algorithm
     Content-Type: application/json

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -63,7 +63,9 @@ Compaction Daemon Rules
     - ``db_fragmentation``: If the ratio of legacy data, including metadata, to
       current data in the database file size is equal to or greater than this
       value, this condition is satisfied. The percentage is expressed as an
-      integer percentage. This value is computed as::
+      integer percentage. This value is computed as:
+
+      .. code-block:: javascript
 
         (file_size - data_size) / file_size * 100
 
@@ -74,7 +76,9 @@ Compaction Daemon Rules
       to current data in a view index file size is equal to or greater then
       this value, this database compaction condition is satisfied. The
       percentage is expressed as an integer percentage. This value is computed
-      as::
+      as:
+
+      .. code-block:: javascript
 
           (file_size - data_size) / file_size * 100
 
@@ -83,7 +87,9 @@ Compaction Daemon Rules
 
     - ``from`` and ``to``: The period for which a database (and its view group)
       compaction is allowed. The value for these parameters must obey the
-      format::
+      format:
+
+      .. code-block:: none
 
           HH:MM - HH:MM  (HH in [0..23], MM in [0..59])
 

--- a/src/config/externals.rst
+++ b/src/config/externals.rst
@@ -43,19 +43,27 @@ OS Daemons
 
     This will make CouchDB bring up the command and attempt to keep it alive.
     To request a configuration parameter, an `os_daemon` can write a simple
-    JSON message to stdout like such::
+    JSON message to stdout like such:
+
+    .. code-block:: none
 
         ["get", "os_daemons"]\n
 
-    which would return::
+    which would return:
+
+    .. code-block:: none
 
         {"daemon_name": "/path/to/command -with args"}\n
 
-    Or::
+    Or:
+
+    .. code-block:: none
 
         ["get", "os_daemons", "daemon_name"]\n
 
-    which would return::
+    which would return:
+
+    .. code-block:: none
 
         "/path/to/command -with args"\n
 
@@ -63,26 +71,34 @@ OS Daemons
     also no method for altering the configuration.
 
     If you would like your OS daemon to be restarted in the event that the
-    configuration changes, you can send the following messages::
+    configuration changes, you can send the following messages:
+
+    .. code-block:: none
 
         ["register", $(SECTION)]\n
 
     When anything in that section changes, your OS process will be rebooted so
     it can pick up the new configuration settings. If you want to listen for
-    changes on a specific key, you can send something like::
+    changes on a specific key, you can send something like:
+
+    .. code-block:: none
 
         ["register", $(SECTION), $(KEY)]\n
 
     In this case, CouchDB will only restart your daemon if that exact
     section/key pair changes, instead of anything in that entire section.
 
-    Logging commands look like::
+    Logging commands look like:
+
+    .. code-block:: none
 
         ["log", $(JSON_MESSAGE)]\n
 
     Where ``$(JSON_MESSAGE)`` is arbitrary JSON data. These messages are logged
     at the 'info' level. If you want to log at a different level you can pass
-    messages like such::
+    messages like such:
+
+    .. code-block:: none
 
         ["log", $(JSON_MESSAGE), {"level": $(LEVEL)}]\n
 

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -244,7 +244,7 @@ Secure Socket Level Options
     You will need the `OpenSSL`_ command line tool installed. It probably
     already is.
 
-    .. code-block:: bash
+    .. code-block:: none
 
         shell> mkdir /etc/couchdb/cert
         shell> cd /etc/couchdb/cert
@@ -274,7 +274,7 @@ Secure Socket Level Options
     Now start (or restart) CouchDB. You should be able to connect to it
     using HTTPS on port 6984:
 
-    .. code-block:: bash
+    .. code-block:: none
 
         shell> curl https://127.0.0.1:6984/
         curl: (60) SSL certificate problem, verify that the CA cert is OK. Details:
@@ -297,7 +297,7 @@ Secure Socket Level Options
     notifies you. Luckily you trust yourself (don't you?) and you can specify
     the ``-k`` option as the message reads:
 
-    .. code-block:: bash
+    .. code-block:: none
 
         shell> curl -k https://127.0.0.1:6984/
         {"couchdb":"Welcome","version":"1.5.0"}
@@ -549,7 +549,7 @@ Virtual Hosts
 
     Test that this is working:
 
-    .. code-block:: bash
+    .. code-block:: none
 
         $ ping -n 2 couchdb.local
         PING couchdb.local (127.0.0.1) 56(84) bytes of data.

--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -43,12 +43,16 @@ target operation system and may be changed during building from the source
 code. For binary distributions, it mostly points to the installation path
 (e.g. ``C:\Program Files\CouchDB\etc\couchdb`` for Windows).
 
-To see the actual configuration files chain run in shell::
+To see the actual configuration files chain run in shell:
+
+.. code-block:: none
 
     couchdb -c
 
 This will print out all *actual* configuration files that will form the result
-CouchDB configuration::
+CouchDB configuration:
+
+.. code-block:: none
 
     /etc/couchdb/default.ini
     /etc/couchdb/default.d/geocouch.ini
@@ -71,7 +75,9 @@ by using next command line options:
 - ``-a``: adds configuration file to the chain
 - ``-A``: adds configuration directory to the chain
 
-Let's add these options and see how the configuration chain changes::
+Let's add these options and see how the configuration chain changes:
+
+.. code-block:: none
 
     shell> couchdb -c -a /home/couchdb/custom.ini
     /etc/couchdb/default.ini
@@ -104,7 +110,9 @@ The common way to set some parameters is to edit the `local.ini` file which is
 mostly located in the `etc/couchdb` directory relative your installation path
 root.
 
-For example::
+For example:
+
+.. code-block:: none
 
     ; This is a comment
     [section]
@@ -145,17 +153,23 @@ Setting parameters via the HTTP API
 
 Alternatively, configuration parameters could be set via the
 :ref:`HTTP API <api/config>`. This API allows to change CouchDB configuration
-on-the-fly without requiring a server restart::
+on-the-fly without requiring a server restart:
+
+.. code-block:: none
 
     curl -X PUT http://localhost:5984/_config/uuids/algorithm -d '"random"'
 
-In the response the old parameter's value returns::
+In the response the old parameter's value returns:
+
+.. code-block:: none
 
     "sequential"
 
 You should be careful with changing configuration via the HTTP API since it's
 easy to make CouchDB unavailable. For instance, if you'd like to change the
-:option:`httpd/bind_address` for a new one::
+:option:`httpd/bind_address` for a new one:
+
+.. code-block:: none
 
     curl -X PUT http://localhost:5984/_config/httpd/bind_address -d '"10.10.0.128"'
 

--- a/src/contributing.rst
+++ b/src/contributing.rst
@@ -85,25 +85,33 @@ We see ascii tables with some additional formatting, all looking like the
 final HTML. So far so easy. For now, let's just add to the bottom of this. We
 can worry about organising this better later.
 
-We start by adding a new headline::
+We start by adding a new headline:
+
+.. code-block:: none
 
     Number Handling
     ===============
 
 Now we paste in the rest of the main email of the thread. It is mostly text,
-but it includes some code listings. Let's mark them up. We'll turn::
+but it includes some code listings. Let's mark them up. We'll turn:
+
+.. code-block:: none
 
     ejson:encode(ejson:decode(<<"1.1">>)).
     <<"1.1000000000000000888">>
 
-Into::
+Into:
+
+.. code-block:: none
 
     .. code-block:: erlang
 
         ejson:encode(ejson:decode(<<"1.1">>)).
         <<"1.1000000000000000888">>
 
-And we follow along with the other code samples. We turn::
+And we follow along with the other code samples. We turn:
+
+.. code-block:: none
 
     Spidermonkey
 
@@ -116,9 +124,13 @@ And we follow along with the other code samples. We turn::
     js> JSON.stringify(JSON.parse(f))
     "1.0123456789012346"
 
-into::
+into:
 
-    Spidermonkey::
+.. code-block:: none
+
+    Spidermonkey:
+
+    .. code-block:: none
 
         $ js -h 2>&1 | head -n 1
         JavaScript-C 1.8.5 2011-03-31
@@ -137,13 +149,17 @@ entry as opposed to a post on a mailing list.
 The next step would be to validate that we got all the markup right. I'll
 leave this for later. For now we'll contribute our change back to CouchDB.
 
-First, we commit our changes::
+First, we commit our changes:
+
+.. code-block:: none
 
     $ > git commit -am 'document number encoding'
     [master a84b2cf] document number encoding
     1 file changed, 199 insertions(+)
 
-Then we push the commit to our CouchDB fork::
+Then we push the commit to our CouchDB fork:
+
+.. code-block:: none
 
     $ git push origin master
 
@@ -159,7 +175,9 @@ Style Guidelines for this Documentation
 When you make a change to the documentation, you should make sure that you
 follow the style. Look through some files and you will see that the style is
 quite straightforward. If you do not know if your formating is in compliance
-with the style, ask yourself the following question::
+with the style, ask yourself the following question:
+
+.. code-block:: none
 
     Is it needed for correct syntax?
 
@@ -204,7 +222,9 @@ The guidelines are in descending priority.
 
    * The highest level titles in a file is over and underlined with ``=``.
    * Lower level titles are underlined with the following characters in
-     descending order::
+     descending order:
+
+     .. code-block:: none
 
         = - ^ *  + # ` : . " ~ _
 

--- a/src/contributing.rst
+++ b/src/contributing.rst
@@ -16,61 +16,47 @@
 Contributing to this Documentation
 ==================================
 
-The documentation lives in the CouchDB source tree. We'll start by forking and
-closing the CouchDB GitHub mirror. That will allow us to send the contribution
-to CouchDB with a pull request.
+The documentation lives in its own source tree, separate from CouchDB.
+We'll start by forking and cloning the CouchDB documentation GitHub mirror.
+That will allow us to send the contribution to CouchDB with a pull request.
 
 If you don't have a GitHub account yet, it is a good time to get one, they are
 free. If you don't want to use GitHub, there are alternate ways to
 contributing back, that we'll cover next time.
 
-Go to https://github.com/apache/couchdb and click the "fork" button in the top
-right. This will create a fork of CouchDB in your GitHub account. Mine is
-`janl`, so my fork lives at https://github.com/janl/couchdb. In the header, it
+Go to https://github.com/apache/couchdb-documentation and click the
+"fork" button in the top right. This will create a fork of CouchDB in
+your GitHub account. Mine is `exclsr`, so my fork lives at
+https://github.com/exclsr/couchdb-documentation. In the header, it
 tells me me my "GitHub Clone URL". We need to copy that and start a terminal:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/janl/couchdb.git
-    $ cd couchdb
+    $ git clone https://github.com/exclsr/couchdb-documentation.git
+    $ cd couchdb-documentation
     $ subl .
 
-I'm opening the whole CouchDB source tree in my favourite editor. It gives
+I'm opening the CouchDB documentation source tree in my favourite editor. It gives
 me the usual directory listing:
 
 .. code-block:: bash
 
     .git/
     .gitignore
-    .mailmap
     .travis.yml
-    AUTHORS
-    BUGS
-    CHANGES
-    DEVELOPERS
-    INSTALL
-    INSTALL.Unix
-    INSTALL.Windows
     LICENSE
-    Makefile.am
-    NEWS
+    Makefile
     NOTICE
-    README
-    THANKS.in
-    acinclude.m4.in
-    bin/
-    bootstrap
-    build-aux/
-    configure.ac
-    etc/
-    license.skip
-    share/
-    src/
-    test/
-    utils/
-    var/
+    ext
+    images
+    make.bat
+    rebar.config
+    src
+    static
+    templates
+    themes
 
-The documentation sources live in `share/doc/src`, you can safely ignore all
+The documentation sources live in `src`, and you can safely ignore all
 the other files and directories.
 
 First we should determine where we want to document this inside the
@@ -89,7 +75,7 @@ but we'll leave this for later.
 
 Let's try and find the source file that builds the file
 http://docs.couchdb.org/en/latest/json-structure.html -- we are in luck, under
-`share/doc/src` we find the file `json-structure.rst`. That looks promising.
+`src` we find the file `json-structure.rst`. That looks promising.
 `.rst` stands for ReStructured Text (see
 http://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html
 for a markup reference), which is an ascii format for writing
@@ -161,8 +147,8 @@ Then we push the commit to our CouchDB fork::
 
     $ git push origin master
 
-Next, we go back to our GitHub page https://github.com/janl/couchdb and click
-the "Pull Request" button. Fill in the description with something useful and
+Next, we go back to our GitHub page https://github.com/exclsr/couchdb-documentation and click
+the "New Pull Request" button. Fill in the description with something useful and
 hit the "Send Pull Request" button.
 
 And we're done!

--- a/src/couchapp/ddocs.rst
+++ b/src/couchapp/ddocs.rst
@@ -478,7 +478,9 @@ events (documents with status `new`). Our filter function will look like this:
 
 Filter functions must return ``true`` if a document passed all defined rules.
 Now, if you apply this function to the changes feed it will emit only changes
-about "new mails"::
+about "new mails":
+
+.. code-block:: none
 
     GET /somedatabase/_changes?filter=mailbox/new_mail HTTP/1.1
 
@@ -520,7 +522,9 @@ The dynamic version of our filter looks like this:
     }
 
 and now we have passed the `status` query parameter in request to let our filter
-match only required documents::
+match only required documents:
+
+.. code-block:: none
 
     GET /somedatabase/_changes?filter=mailbox/by_status&status=new HTTP/1.1
 
@@ -532,7 +536,9 @@ match only required documents::
     ],
     "last_seq":27}
 
-and we can easily change filter behavior with::
+and we can easily change filter behavior with:
+
+.. code-block:: none
 
     GET /somedatabase/_changes?filter=mailbox/by_status&status=spam HTTP/1.1
 
@@ -557,7 +563,9 @@ time a key-value pair could be emitted, a change is returned. This allows us
 to avoid creating filter functions that mostly do the same works as views.
 
 To use them just specify `_view` value for ``filter`` parameter and
-`designdoc/viewname` for ``view`` one::
+`designdoc/viewname` for ``view`` one:
+
+.. code-block:: none
 
     GET /somedatabase/_changes?filter=_view&view=dname/viewname  HTTP/1.1
 

--- a/src/couchapp/views/collation.rst
+++ b/src/couchapp/views/collation.rst
@@ -56,7 +56,9 @@ associated orders. The values 0 and 1 for the sorting token are arbitrary.
 
 To list a specific customer with ``_id`` XYZ, and all of that customer's orders,
 limit the startkey and endkey ranges to cover only documents for that customer's
-``_id``::
+``_id``:
+
+.. code-block:: none
 
     startkey=["XYZ"]&endkey=["XYZ", {}]
 
@@ -95,11 +97,15 @@ If you need start and end keys that encompass every string with a given prefix,
 it is better to use a high value unicode character, than to use a ``'ZZZZ'``
 suffix.
 
-That is, rather than::
+That is, rather than:
+
+.. code-block:: none
 
     startkey="abc"&endkey="abcZZZZZZZZZ"
 
-You should use::
+You should use:
+
+.. code-block:: none
 
     startkey="abc"&endkey="abc\ufff0"
 
@@ -200,7 +206,9 @@ You can demonstrate the collation sequence for 7-bit ASCII characters like this:
 
     puts RestClient.get("#{DB}/_design/test/_view/one")
 
-This shows the collation sequence to be::
+This shows the collation sequence to be:
+
+.. code-block:: none
 
     ` ^ _ - , ; : ! ? . ' " ( ) [ ] { } @ * / \ & # % + < = > | ~ $ 0 1 2 3 4 5 6 7 8 9
     a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z
@@ -208,15 +216,21 @@ This shows the collation sequence to be::
 Key ranges
 ----------
 
-Take special care when querying key ranges. For example: the query::
+Take special care when querying key ranges. For example: the query:
+
+.. code-block:: none
 
     startkey="Abc"&endkey="AbcZZZZ"
 
-will match "ABC" and "abc1", but not "abc". This is because UCA sorts as::
+will match "ABC" and "abc1", but not "abc". This is because UCA sorts as:
+
+.. code-block:: none
 
     abc < Abc < ABC < abc1 < AbcZZZZZ
 
-For most applications, to avoid problems you should lowercase the `startkey`::
+For most applications, to avoid problems you should lowercase the `startkey`:
+
+.. code-block:: none
 
     startkey="abc"&endkey="abcZZZZZZZZ"
 
@@ -233,12 +247,16 @@ _all_docs
 =========
 
 The :ref:`_all_docs <api/db/all_docs>`  view is a special case because it uses
-ASCII collation for doc ids, not UCA::
+ASCII collation for doc ids, not UCA:
+
+.. code-block:: none
 
     startkey="_design/"&endkey="_design/ZZZZZZZZ"
 
 will not find ``_design/abc`` because `'Z'` comes before `'a'` in the ASCII
-sequence. A better solution is::
+sequence. A better solution is:
+
+.. code-block:: none
 
     startkey="_design/"&endkey="_design0"
 

--- a/src/couchapp/views/intro.rst
+++ b/src/couchapp/views/intro.rst
@@ -232,7 +232,9 @@ Find Many
 ---------
 
 We talked about “getting all posts for last month.” If it’s February now,
-this is as easy as::
+this is as easy as:
+
+.. code-block:: none
 
     /blog/_design/docs/_view/by_date?startkey="2010/01/01 00:00:00"&endkey="2010/02/00 00:00:00"
 
@@ -269,7 +271,9 @@ Table 2. New view results:
 | [2009, 1, 30, 18, 4, 11]  | "Bought a Cat"   |
 +---------------------------+------------------+
 
-And our queries change to::
+And our queries change to:
+
+.. code-block:: none
 
     /blog/_design/docs/_view/by_date?startkey=[2010, 1, 1, 0, 0, 0]&endkey=[2010, 2, 1, 0, 0, 0]
 

--- a/src/couchapp/views/joins.rst
+++ b/src/couchapp/views/joins.rst
@@ -406,7 +406,9 @@ the following:
     corresponding documents
 
 Now, to get a specific blog post and all associated comments, we'd invoke that
-view with the query string::
+view with the query string:
+
+.. code-block:: none
 
     ?startkey=["myslug"]&endkey;=["myslug", 2]
 

--- a/src/couchapp/views/nosql.rst
+++ b/src/couchapp/views/nosql.rst
@@ -26,11 +26,15 @@ documents.
 Using Views
 ===========
 
-How you would do this in SQL::
+How you would do this in SQL:
+
+.. code-block:: sql
 
     CREATE TABLE
 
-or::
+or:
+
+.. code-block:: sql
 
     ALTER TABLE
 
@@ -94,7 +98,9 @@ Querying a View
 
 The name of the design document and the name of the view are significant for
 querying the view. To query the view `viewname`, you perform an HTTP ``GET``
-request to the following URI::
+request to the following URI:
+
+.. code-block:: none
 
     /database/_design/application/_view/viewname
 
@@ -158,7 +164,9 @@ and value.
 Look Up by Key
 ==============
 
-How you would do this in SQL::
+How you would do this in SQL:
+
+.. code-block:: sql
 
     SELECT field FROM table WHERE value="searchterm"
 
@@ -184,7 +192,9 @@ view. All we need is a simple map function:
 
 This creates a list of documents that have a value field sorted by the data in
 the value field. To find all the records that match "searchterm", we query the
-view and specify the search term as a query parameter::
+view and specify the search term as a query parameter:
+
+.. code-block:: none
 
     /database/_design/application/_view/viewname?key="searchterm"
 
@@ -199,7 +209,9 @@ age field of the documents to find all the five-year-olds:
         }
     }
 
-Query::
+Query:
+
+.. code-block:: none
 
     /ladies/_design/ladies/_view/age?key=5
 
@@ -221,7 +233,9 @@ fetch the individual documents for us.
 Look Up by Prefix
 =================
 
-How you would do this in SQL::
+How you would do this in SQL:
+
+.. code-block:: sql
 
     SELECT field FROM table WHERE value LIKE "searchterm%"
 
@@ -263,14 +277,18 @@ match our prefix:
     }
 
 We can now query this view with our desired MIME type prefix and not only find
-all images, but also text, video, and all other formats::
+all images, but also text, video, and all other formats:
+
+.. code-block:: none
 
     /files/_design/finder/_view/by-mime-type?key="image/"
 
 Aggregate Functions
 ===================
 
-How you would do this in SQL::
+How you would do this in SQL:
+
+.. code-block:: sql
 
     SELECT COUNT(field) FROM table
 
@@ -373,7 +391,9 @@ if you try to use reduce “the wrong way”:
 Get Unique Values
 =================
 
-How you would do this in SQL::
+How you would do this in SQL:
+
+.. code-block:: sql
 
     SELECT DISTINCT field FROM table
 
@@ -447,7 +467,9 @@ uniqueness, we need a reduce:
     }
 
 This reduce doesn’t do anything, but it allows us to specify a special query
-parameter when querying the view::
+parameter when querying the view:
+
+.. code-block:: none
 
     /dudes/_design/dude-data/_view/tags?group=true
 
@@ -509,7 +531,9 @@ count for each tag:
 Enforcing Uniqueness
 ====================
 
-How you would do this in SQL::
+How you would do this in SQL:
+
+.. code-block:: sql
 
     UNIQUE KEY(column)
 

--- a/src/couchapp/views/pagination.rst
+++ b/src/couchapp/views/pagination.rst
@@ -127,7 +127,9 @@ Paging
 ======
 
 To get the first five rows from the view result, you use the ``?limit=5``
-query parameter::
+query parameter:
+
+.. code-block:: none
 
     curl -X GET http://127.0.0.1:5984/artists/_design/artists/_view/by-name?limit=5
 
@@ -154,7 +156,9 @@ we can determine if there are more pages to display. We also know by the
     var page = (offset / rows_per_page) + 1; // == 1
     var skip = page * rows_per_page; // == 5 for the first page, 10 for the second ...
 
-So we query CouchDB with::
+So we query CouchDB with:
+
+.. code-block:: none
 
     curl -X GET 'http://127.0.0.1:5984/artists/_design/artists/_view/by-name?limit=5&skip=5'
 

--- a/src/cve/2012-5641.rst
+++ b/src/cve/2012-5641.rst
@@ -57,7 +57,9 @@ within their configuration file, typically in `local.ini`. On a default
 CouchDB installation, this requires amending the
 :config:option:`httpd_global_handlers/favicon.ico` and
 :config:option:`httpd_global_handlers/_utils` lines within
-:config:section:`httpd_global_handlers`::
+:config:section:`httpd_global_handlers`:
+
+.. code-block:: ini
 
     [httpd_global_handlers]
     favicon.ico = {couch_httpd_misc_handlers, handle_welcome_req, <<"Forbidden">>}

--- a/src/cve/2012-5650.rst
+++ b/src/cve/2012-5650.rst
@@ -48,7 +48,9 @@ Work-Around
 ===========
 
 Disable the Futon user interface completely, by adapting `local.ini` and
-restarting CouchDB::
+restarting CouchDB:
+
+.. code-block:: ini
 
   [httpd_global_handlers]
   _utils = {couch_httpd_misc_handlers, handle_welcome_req, <<"Forbidden">>}

--- a/src/cve/2014-2668.rst
+++ b/src/cve/2014-2668.rst
@@ -48,7 +48,9 @@ Work-Around
 ===========
 
 Disable the :ref:`api/server/uuids` handler completely, by adapting
-`local.ini` and restarting CouchDB::
+`local.ini` and restarting CouchDB:
+
+.. code-block:: ini
 
     [httpd_global_handlers]
     _uuids =

--- a/src/experimental.rst
+++ b/src/experimental.rst
@@ -36,12 +36,16 @@ Setup
 You will need to install Node.JS version 0.10.0 or later. See `Node.JS
 Downloads <http://nodejs.org/download/>`_ for options.
 
-1. Install the `couchjs-node` binary. Either from the CouchDB sources::
+1. Install the `couchjs-node` binary. Either from the CouchDB sources:
+
+.. code-block:: none
 
     cd src/couchjs-node
     npm link
 
-Or via NPM::
+Or via NPM:
+
+.. code-block:: none
 
     npm install -g couchjs
 

--- a/src/externals.rst
+++ b/src/externals.rst
@@ -70,7 +70,9 @@ How does it work? - HTTP Proxying
 =================================
 
 To configure a :ref:`proxy handler <config/proxy>`, edit your `local.ini` and
-add a section like such::
+add a section like such:
+
+.. code-block:: ini
 
     [httpd_global_handlers]
     _fti = {couch_httpd_proxy, handle_proxy_req, <<"http://127.0.0.1:5985">>}
@@ -103,7 +105,9 @@ processes, you need to either tell CouchDB about each one, or have a main
 process that forks off the required sub-processes.
 
 To configure an :config:section:`OS daemon <os_daemons>`, add this to your
-`local.ini`::
+`local.ini`:
+
+.. code-block:: ini
 
     [os_daemons]
     my_daemon = /path/to/command -with args
@@ -118,19 +122,27 @@ if you desire. Or they can peek at things like the
 :config:option:`httpd/bind_address` and :config:option:`httpd/port` that CouchDB
 is using.
 
-A request for a config section looks like this::
+A request for a config section looks like this:
+
+.. code-block:: none
 
     ["get", "os_daemons"]\n
 
-And the response::
+And the response:
+
+.. code-block:: none
 
     {"my_daemon": "/path/to/command -with args"}\n
 
-Or to get a specific key::
+Or to get a specific key:
+
+.. code-block:: none
 
     ["get", "os_daemons", "my_daemon"]\n
 
-And the response::
+And the response:
+
+.. code-block:: none
 
     "/path/to/command -with args"\n
 
@@ -139,7 +151,9 @@ All requests and responses are terminated with a newline (indicated by ``\n``).
 Logging API
 -----------
 
-There's also an API for adding messages to CouchDB's logs. Its simply::
+There's also an API for adding messages to CouchDB's logs. Its simply:
+
+.. code-block:: none
 
     ["log", $MESG]\n
 
@@ -243,7 +257,9 @@ And then start CouchDB and try:
     * Connection #0 to host 127.0.0.1 left intact
     * Closing connection #0
 
-The corresponding CouchDB logs look like::
+The corresponding CouchDB logs look like:
+
+.. code-block:: none
 
     Apache CouchDB 1.5.0 (LogLevel=info) is starting.
     Apache CouchDB has started. Time to relax.

--- a/src/fauxton/addons.rst
+++ b/src/fauxton/addons.rst
@@ -17,7 +17,9 @@ Writing Addons
 ===============
 
 Addons allow you to extend Fauxton for a specific use case. Usually, they
-have the following structure::
+have the following structure:
+
+.. code-block:: none
 
     + my_addon/
     | ---+ assets [optional]
@@ -34,7 +36,9 @@ Generating an Addon
 
 We have a `grunt-init` template that lets you create a skeleton addon,
 including all the boiler plate code. Run ``grunt-init tasks/addon`` and answer
-the questions it asks to create an addon::
+the questions it asks to create an addon:
+
+.. code-block:: none
 
     ± grunt-init tasks/addon
     path.existsSync is now called `fs.existsSync`.
@@ -91,7 +95,9 @@ adds the `searchSidebar` callback to `#sidebar-content` for three routes.
 Hello world Addon
 =================
 
-First create the addon skeleton::
+First create the addon skeleton:
+
+.. code-block:: none
 
     ± bbb addon
     path.existsSync is now called `fs.existsSync`.

--- a/src/fauxton/install.rst
+++ b/src/fauxton/install.rst
@@ -24,7 +24,9 @@ Recent versions of `node.js`_ and `npm`_ are required.
 Get the source
 ==============
 
-Clone the CouchDB repo::
+Clone the CouchDB repo:
+
+.. code-block:: bash
 
     $ git clone http://git-wip-us.apache.org/repos/asf/couchdb.git
     $ cd couchdb
@@ -32,23 +34,31 @@ Clone the CouchDB repo::
 Fauxton Setup
 =============
 
-Install all dependencies::
+Install all dependencies:
+
+.. code-block:: none
 
     couchdb/ $ cd src/fauxton
     couchdb/src/fauxton/ $ npm install
 
 .. note::
-    To avoid a npm global install add ``node_modules/.bin`` to your path::
+    To avoid a npm global install add ``node_modules/.bin`` to your path:
+
+    .. code-block:: none
 
         export PATH=./node_modules/.bin:$PATH
 
     Or just use the wrappers in ``./bin/``.
 
-    Development mode, non minified files::
+    Development mode, non minified files:
+
+    .. code-block:: none
 
         ./bin/grunt couchdebug
 
-    Or fully compiled install::
+    Or fully compiled install:
+
+    .. code-block:: none
 
         ./bin/grunt couchdb
 
@@ -56,7 +66,9 @@ Dev Server
 ==========
 
 Using the dev server is the easiest way to use Fauxton, specially when
-developing for it::
+developing for it:
+
+.. code-block:: none
 
     grunt dev
 
@@ -64,6 +76,8 @@ Deploy Fauxton
 ==============
 
 Deploy Fauxton to your local CouchDB instance:
+
+.. code-block:: none
 
     ./bin/grunt couchapp_deploy
 

--- a/src/install/freebsd.rst
+++ b/src/install/freebsd.rst
@@ -30,13 +30,17 @@ Start script
 ------------
 
 The following options for ``/etc/rc.conf`` or ``/etc/rc.conf.local`` are
-supported by the start script (defaults shown)::
+supported by the start script (defaults shown):
+
+.. code-block:: text
 
     couchdb_enable="NO"
     couchdb_enablelogs="YES"
     couchdb_user="couchdb"
 
-After enabling the couchdb rc service use the following command to start CouchDB::
+After enabling the couchdb rc service use the following command to start CouchDB:
+
+.. code-block:: text
 
     /usr/local/etc/rc.d/couchdb start
 

--- a/src/install/mac.rst
+++ b/src/install/mac.rst
@@ -45,12 +45,16 @@ That's all, now CouchDB is installed on your Mac:
 Installation with HomeBrew
 ==========================
 
-You can install the build tools by running::
+You can install the build tools by running:
+
+.. code-block:: none
 
     open /Applications/Installers/Xcode\ Tools/XcodeTools.mpkg
 
 You will need `Homebrew`_ installed to use the `brew` command. To install the
-other :ref:`dependencies <install/unix/dependencies>` run next commands::
+other :ref:`dependencies <install/unix/dependencies>` run next commands:
+
+.. code-block:: none
 
     brew install autoconf
     brew install autoconf-archive
@@ -62,21 +66,29 @@ other :ref:`dependencies <install/unix/dependencies>` run next commands::
     brew install curl
 
 You may want to link ICU so that CouchDB can find the header files
-automatically::
+automatically:
+
+.. code-block:: none
 
     brew link icu4c
 
-The same is true for recent versions of Erlang::
+The same is true for recent versions of Erlang:
+
+.. code-block:: none
 
     brew link erlang
 
-Now it's time to brew CouchDB::
+Now it's time to brew CouchDB:
+
+.. code-block:: none
 
     brew install couchdb
 
 The above Erlang install will use the bottled (pre-compiled) version if you are:
 using `/usr/local` for `homebrew`, and on 10.6 or 10.7. If you're not on one of
-these, `homebrew` will build from source, so consider doing::
+these, `homebrew` will build from source, so consider doing:
+
+.. code-block:: none
 
     brew install erlang --no-docs
 
@@ -88,7 +100,9 @@ git-based master (head) branch, or the next development release using this
 This will allow quick installation of the future release branch when it becomes
 active. If you're not sure if you need this, then you probably don't.
 In both cases we assume you are comfortable identifying bugs, and handling any
-potential upgrades between commits to the codebase. ::
+potential upgrades between commits to the codebase.
+
+.. code-block:: none
 
     brew install [--devel|--head] couchdb
 
@@ -120,29 +134,41 @@ Running as a Daemon
 
 You can use the `launchctl` command to control the CouchDB daemon.
 
-You can load the configuration by running::
+You can load the configuration by running:
+
+.. code-block:: none
 
     sudo launchctl load \
          /usr/local/Library/LaunchDaemons/org.apache.couchdb.plist
 
-You can stop the CouchDB daemon by running::
+You can stop the CouchDB daemon by running:
+
+.. code-block:: none
 
     sudo launchctl unload \
          /usr/local/Library/LaunchDaemons/org.apache.couchdb.plist
 
-You can start CouchDB by running::
+You can start CouchDB by running:
+
+.. code-block:: none
 
     sudo launchctl start org.apache.couchdb
 
-You can restart CouchDB by running::
+You can restart CouchDB by running:
+
+.. code-block:: none
 
     sudo launchctl stop org.apache.couchdb
 
-You can edit the launchd configuration by running::
+You can edit the launchd configuration by running:
+
+.. code-block:: none
 
     open /usr/local/Library/LaunchDaemons/org.apache.couchdb.plist
 
-To start the daemon on boot, copy the configuration file to::
+To start the daemon on boot, copy the configuration file to:
+
+.. code-block:: none
 
     /Library/LaunchDaemons
 
@@ -159,20 +185,24 @@ To install CouchDB using MacPorts you have 2 package choices:
 - ``couchdb-devel`` - updated every few weeks with the latest from the master
   branch
 
-::
+.. code-block:: none
 
     $ sudo port install couchdb
 
 should be enough. MacPorts takes care of installing all necessary dependencies.
 If you have already installed some of the CouchDB dependencies via MacPorts,
 run this command to check and upgrade any outdated ones, after installing
-CouchDB::
+CouchDB:
+
+.. code-block:: none
 
     $ sudo port upgrade couchdb
 
 This will upgrade dependencies recursively, if there are more recent versions
 available. If you want to run CouchDB as a service controlled by the OS, load
-the launchd configuration which comes with the project, with this command::
+the launchd configuration which comes with the project, with this command:
+
+.. code-block:: none
 
     $ sudo port load couchdb
 
@@ -180,7 +210,9 @@ and it should be up and accessible via Futon at http://127.0.0.1:5984/_utils.
 It should also be restarted automatically after reboot.
 
 Updating the ports collection. The collection of port files has to be updated
-to reflect the latest versions of available packages. In order to do that run::
+to reflect the latest versions of available packages. In order to do that run:
+
+.. code-block:: none
 
     $ sudo port selfupdate
 

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -68,7 +68,9 @@ Python and Sphinx are only required for building the online documentation.
 Debian-based Systems
 --------------------
 
-You can install the dependencies by running::
+You can install the dependencies by running:
+
+.. code-block:: none
 
     sudo apt-get install build-essential
     sudo apt-get install erlang-base-hipe
@@ -95,7 +97,9 @@ Unfortunately, it seems that installing dependencies on Ubuntu is troublesome.
 RedHat-based (Fedora, Centos, RHEL) Systems
 -------------------------------------------
 
-You can install the dependencies by running::
+You can install the dependencies by running:
+
+.. code-block:: none
 
     sudo yum install autoconf
     sudo yum install autoconf-archive
@@ -123,7 +127,9 @@ Follow :ref:`install/mac/homebrew` reference till `brew install couchdb` step.
 Installing
 ==========
 
-Once you have satisfied the dependencies you should run::
+Once you have satisfied the dependencies you should run:
+
+.. code-block:: none
 
     ./configure
 
@@ -131,13 +137,17 @@ This script will configure CouchDB to be installed into `/usr/local` by default.
 
 If you wish to customise the installation, pass `--help` to this script.
 
-If everything was successful you should see the following message::
+If everything was successful you should see the following message:
+
+.. code-block:: none
 
     You have configured Apache CouchDB, time to relax.
 
 Relax.
 
-To install CouchDB you should run::
+To install CouchDB you should run:
+
+.. code-block:: none
 
     make && sudo make install
 
@@ -145,7 +155,9 @@ You only need to use `sudo` if you're installing into a system directory.
 
 Try `gmake` if `make` is giving you any problems.
 
-If everything was successful you should see the following message::
+If everything was successful you should see the following message:
+
+.. code-block:: none
 
     You have installed Apache CouchDB, time to relax.
 
@@ -154,23 +166,31 @@ Relax.
 First Run
 =========
 
-You can start the CouchDB server by running::
+You can start the CouchDB server by running:
+
+.. code-block:: none
 
     sudo -i -u couchdb couchdb
 
 This uses the `sudo` command to run the `couchdb` command as the `couchdb` user.
 
-When CouchDB starts it should eventually display the following message::
+When CouchDB starts it should eventually display the following message:
+
+.. code-block:: none
 
     Apache CouchDB has started, time to relax.
 
 Relax.
 
-To check that everything has worked, point your web browser to::
+To check that everything has worked, point your web browser to:
+
+.. code-block:: none
 
     http://127.0.0.1:5984/_utils/index.html
 
-From here you should verify your installation by pointing your web browser to::
+From here you should verify your installation by pointing your web browser to:
+
+.. code-block:: none
 
     http://localhost:5984/_utils/verify_install.html
 
@@ -179,7 +199,9 @@ Security Considerations
 
 You should create a special `couchdb` user for CouchDB.
 
-On many Unix-like systems you can run::
+On many Unix-like systems you can run:
+
+.. code-block:: none
 
     adduser --system \
             --home /usr/local/var/lib/couchdb \
@@ -200,14 +222,18 @@ You can test this by:
 * Trying to log in as the `couchdb` user
 * Running `pwd` and checking the present working directory
 
-Change the ownership of the CouchDB directories by running::
+Change the ownership of the CouchDB directories by running:
+
+.. code-block:: none
 
     chown -R couchdb:couchdb /usr/local/etc/couchdb
     chown -R couchdb:couchdb /usr/local/var/lib/couchdb
     chown -R couchdb:couchdb /usr/local/var/log/couchdb
     chown -R couchdb:couchdb /usr/local/var/run/couchdb
 
-Change the permission of the CouchDB directories by running::
+Change the permission of the CouchDB directories by running:
+
+.. code-block:: none
 
     chmod 0770 /usr/local/etc/couchdb
     chmod 0770 /usr/local/var/lib/couchdb
@@ -224,39 +250,53 @@ SysV/BSD-style Systems
 
 You can use the `couchdb` init script to control the CouchDB daemon.
 
-On SysV-style systems, the init script will be installed into::
+On SysV-style systems, the init script will be installed into:
+
+.. code-block:: none
 
     /usr/local/etc/init.d
 
-On BSD-style systems, the init script will be installed into::
+On BSD-style systems, the init script will be installed into:
+
+.. code-block:: none
 
     /usr/local/etc/rc.d
 
 We use the `[init.d|rc.d]` notation to refer to both of these directories.
 
-You can control the CouchDB daemon by running::
+You can control the CouchDB daemon by running:
+
+.. code-block:: none
 
     /usr/local/etc/[init.d|rc.d]/couchdb [start|stop|restart|status]
 
-If you wish to configure how the init script works, you can edit::
+If you wish to configure how the init script works, you can edit:
+
+.. code-block:: none
 
     /usr/local/etc/default/couchdb
 
 Comment out the `COUCHDB_USER` setting if you're running as a non-superuser.
 
-To start the daemon on boot, copy the init script to::
+To start the daemon on boot, copy the init script to:
+
+.. code-block:: none
 
     /etc/[init.d|rc.d]
 
 You should then configure your system to run the init script automatically.
 
-You may be able to run::
+You may be able to run:
+
+.. code-block:: none
 
     sudo update-rc.d couchdb defaults
 
 If this fails, consult your system documentation for more information.
 
-A `logrotate` configuration is installed into::
+A `logrotate` configuration is installed into:
+
+.. code-block:: none
 
     /usr/local/etc/logrotate.d/couchdb
 

--- a/src/install/windows.rst
+++ b/src/install/windows.rst
@@ -129,11 +129,15 @@ General Notes
 Setting Up Cygwin
 -----------------
 
-Before starting any Cygwin terminals, run::
+Before starting any Cygwin terminals, run:
+
+.. code-block:: none
 
     set CYGWIN=nontsec
 
-To set up your environment, run::
+To set up your environment, run:
+
+.. code-block:: none
 
     [VS_BIN]/vcvars32.bat
 
@@ -160,7 +164,9 @@ Building Erlang
 You must include Win32 OpenSSL, built statically from source. Use
 exactly the same version as required by the Erlang/OTP build process.
 
-However, you can skip the GUI tools by running::
+However, you can skip the GUI tools by running:
+
+.. code-block:: none
 
     echo "skipping gs" > lib/gs/SKIP
 
@@ -170,11 +176,15 @@ However, you can skip the GUI tools by running::
 
 Follow the rest of the Erlang instructions as described.
 
-After running::
+After running:
+
+.. code-block:: none
 
     ./otp_build release -a
 
-You should run::
+You should run:
+
+.. code-block:: none
 
     ./release/win32/Install.exe -s
 
@@ -182,11 +192,15 @@ This will set up the release/win32/bin directory correctly. The CouchDB
 installation scripts currently write their data directly into this
 location.
 
-To set up your environment for building CouchDB, run::
+To set up your environment for building CouchDB, run:
+
+.. code-block:: none
 
     eval `./otp_build env_win32`
 
-To set up the `ERL_TOP` environment variable, run::
+To set up the `ERL_TOP` environment variable, run:
+
+.. code-block:: none
 
     export ERL_TOP=[ERL_TOP]
 
@@ -194,7 +208,9 @@ Replace ``[ERL_TOP]`` with the Erlang source directory name.
 
 Remember to use `/cygdrive/c/` instead of `c:/` as the directory prefix.
 
-To set up your path, run::
+To set up your path, run:
+
+.. code-block:: none
 
     export PATH=$ERL_TOP/release/win32/erts-5.8.5/bin:$PATH
 
@@ -210,7 +226,9 @@ tests.
 
 The documentation step may be skipped using ``--disable-docs`` if you wish.
 
-Once you have satisfied the dependencies you should run::
+Once you have satisfied the dependencies you should run:
+
+.. code-block:: none
 
     ./configure \
         --with-js-include=/cygdrive/c/path_to_spidermonkey_include \
@@ -226,23 +244,31 @@ Once you have satisfied the dependencies you should run::
 
 This command could take a while to complete.
 
-If everything was successful you should see the following message::
+If everything was successful you should see the following message:
+
+.. code-block:: none
 
     You have configured Apache CouchDB, time to relax.
 
 Relax.
 
-To install CouchDB you should run::
+To install CouchDB you should run:
+
+.. code-block:: none
 
     make install
 
-If everything was successful you should see the following message::
+If everything was successful you should see the following message:
+
+.. code-block:: none
 
     You have installed Apache CouchDB, time to relax.
 
 Relax.
 
-To build the .exe installer package, you should run::
+To build the .exe installer package, you should run:
+
+.. code-block:: none
 
     make dist
 
@@ -252,17 +278,23 @@ to avoid any contamination do not run `make dist` after this.
 First Run
 ---------
 
-You can start the CouchDB server by running::
+You can start the CouchDB server by running:
+
+.. code-block:: none
 
     $ERL_TOP/release/win32/bin/couchdb.bat
 
-When CouchDB starts it should eventually display the following message::
+When CouchDB starts it should eventually display the following message:
+
+.. code-block:: none
 
     Apache CouchDB has started, time to relax.
 
 Relax.
 
-To check that everything has worked, point your web browser to::
+To check that everything has worked, point your web browser to:
+
+.. code-block:: none
 
     http://127.0.0.1:5984/_utils/index.html
 

--- a/src/intro/api.rst
+++ b/src/intro/api.rst
@@ -46,7 +46,9 @@ Server
 This one is basic and simple. It can serve as a sanity check to see if
 CouchDB is running at all. It can also act as a safety guard for libraries
 that require a certain version of CouchDB. We're using the `curl`_ utility
-again::
+again:
+
+.. code-block:: none
 
   curl http://127.0.0.1:5984/
 
@@ -89,7 +91,9 @@ talking about the whole of CouchDB or a single database within CouchDB.
 Now let's make one! We want to store our favorite music albums,
 and we creatively give our database the name albums. Note that we're now
 using the ``-X`` option again to tell curl to send a :method:`PUT` request
-instead of the default :method:`GET` request::
+instead of the default :method:`GET` request:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/albums
 
@@ -101,7 +105,9 @@ CouchDB replies:
 
 That's it. You created a database and CouchDB told you that all went well.
 What happens if you try to create a database that already exists? Let's try
-to create that database again::
+to create that database again:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/albums
 
@@ -117,11 +123,15 @@ Very simple.
 
 Let's create another database, this time with curl's ``-v`` (for "verbose")
 option. The verbose option tells curl to show us not only the essentials --
-the HTTP response body -- but all the underlying request and response details::
+the HTTP response body -- but all the underlying request and response details:
+
+.. code-block:: none
 
     curl -vX PUT http://127.0.0.1:5984/albums-backup
 
-curl elaborates::
+curl elaborates:
+
+.. code-block:: none
 
     * About to connect() to 127.0.0.1 port 5984 (#0)
     *   Trying 127.0.0.1... connected
@@ -144,13 +154,17 @@ curl elaborates::
 
 What a mouthful. Let's step through this line by line to understand what's
 going on and find out what's important. Once you've seen this output a few
-times, you'll be able to spot the important bits more easily. ::
+times, you'll be able to spot the important bits more easily.
+
+.. code-block:: none
 
     * About to connect() to 127.0.0.1 port 5984 (#0)
 
 This is curl telling us that it is going to establish a TCP connection to the
 CouchDB server we specified in our request URI. Not at all important,
-except when debugging networking issues. ::
+except when debugging networking issues.
+
+.. code-block:: none
 
     *   Trying 127.0.0.1... connected
     * Connected to 127.0.0.1 (127.0.0.1) port 5984 (#0)
@@ -160,7 +174,9 @@ not important if you aren't trying to find problems with your network.
 
 The following lines are prefixed with ``>`` and ``<`` characters.
 The ``>`` means the line was sent to CouchDB verbatim (without the actual
-``>``). The ``<`` means the line was sent back to curl by CouchDB. ::
+``>``). The ``<`` means the line was sent back to curl by CouchDB.
+
+.. code-block:: none
 
     > PUT /albums-backup HTTP/1.1
 
@@ -170,7 +186,9 @@ This initiates an HTTP request. Its *method* is :method:`PUT`, the *URI* is
 you should be using ``HTTP/1.1``.
 
 Next, we see a number of *request headers*. These are used to provide
-additional details about the request to CouchDB. ::
+additional details about the request to CouchDB.
+
+.. code-block:: none
 
     > User-Agent: curl/7.16.3 (powerpc-apple-darwin9.0) libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3
 
@@ -180,24 +198,32 @@ often useful in web development when there are known errors in client
 implementations that a server might want to prepare the response for.
 It also helps to determine which platform a user is on. This information
 can be used for technical and statistical reasons. For CouchDB, the
-:header:`User-Agent` header is irrelevant. ::
+:header:`User-Agent` header is irrelevant.
+
+.. code-block:: none
 
     > Host: 127.0.0.1:5984
 
 The :header:`Host` header is required by ``HTTP 1.1``. It tells the server
-the hostname that came with the request. ::
+the hostname that came with the request.
+
+.. code-block:: none
 
     > Accept: */*
 
 The :header:`Accept` header tells CouchDB that curl accepts any media type.
-We'll look into why this is useful a little later. ::
+We'll look into why this is useful a little later.
+
+.. code-block:: none
 
     >
 
 An empty line denotes that the request headers are now finished and the rest
 of the request contains data we're sending to the server. In this case,
 we're not sending any data, so the rest of the curl output is dedicated to
-the HTTP response. ::
+the HTTP response.
+
+.. code-block:: none
 
     < HTTP/1.1 201 Created
 
@@ -218,21 +244,27 @@ response code. Acting upon responses based on response codes is a common
 practice. For example, all response codes of :statuscode:`400` or larger
 tell you that some error occurred. If you want to shortcut your logic and
 immediately deal with the error, you could just check a >= ``400`` response
-code. ::
+code.
+
+.. code-block:: none
 
     < Server: CouchDB (Erlang/OTP)
 
 The :header:`Server` header is good for diagnostics. It tells us which
 CouchDB version and which underlying Erlang version we are talking to.
 In general, you can ignore this header, but it is good to know it's there if
-you need it. ::
+you need it.
+
+.. code-block:: none
 
     < Date: Sun, 05 Jul 2009 22:48:28 GMT
 
 The :header:`Date` header tells you the time of the server. Since client
 and server time are not necessarily synchronized, this header is purely
 informational. You shouldn't build any critical application logic on top
-of this! ::
+of this!
+
+.. code-block:: none
 
     < Content-Type: text/plain;charset=utf-8
 
@@ -258,17 +290,23 @@ Do you remember the :header:`Accept` request header and how it is set to
 ``*/*`` to express interest in any MIME type? If you send ``Accept:
 application/json`` in your request, CouchDB knows that you can deal with a pure
 JSON response with the proper :header:`Content-Type` header and will
-use it instead of :mimetype:`text/plain`. ::
+use it instead of :mimetype:`text/plain`.
+
+.. code-block:: none
 
     < Content-Length: 12
 
 The :header:`Content-Length` header simply tells us how many bytes
-the response body has. ::
+the response body has.
+
+.. code-block:: none
 
     < Cache-Control: must-revalidate
 
 This :header:`Cache-Control` header tells you, or any proxy server between
-CouchDB and you, not to cache this response. ::
+CouchDB and you, not to cache this response.
+
+.. code-block:: none
 
     <
 
@@ -279,7 +317,9 @@ follows now is the response body.
 
     {"ok":true}
 
-We've seen this before. ::
+We've seen this before.
+
+.. code-block:: none
 
     * Connection #0 to host 127.0.0.1 left intact
     * Closing connection #0
@@ -293,7 +333,9 @@ but we'll omit some of the headers we've seen here and include only those
 that are important for the particular request.
 
 Creating databases is all fine, but how do we get rid of one? Easy -- just
-change the HTTP method::
+change the HTTP method:
+
+.. code-block:: none
 
     > curl -vX DELETE http://127.0.0.1:5984/albums-backup
 
@@ -328,7 +370,9 @@ cannot create two different documents with the same ID. Why should you care
 what somebody else is doing? For one, that somebody else could be you at a
 later time or on a different computer; secondly, CouchDB replication lets you
 share documents with others and using UUIDs ensures that it all works.
-But more on that later; let's make some documents::
+But more on that later; let's make some documents:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af -d '{"title":"There is Nothing Left to Lose","artist":"Foo Fighters"}'
 
@@ -352,7 +396,9 @@ values.
 .. note::
     If you don't have a UUID handy, you can ask CouchDB to give you one (in
     fact, that is what we did just now without showing you). Simply send a
-    :get:`/_uuids` request::
+    :get:`/_uuids` request:
+
+    .. code-block:: none
 
         curl -X GET http://127.0.0.1:5984/_uuids
 
@@ -366,7 +412,9 @@ values.
     HTTP parameter to request 10 UUIDs, or really, any number you need.
 
 To double-check that CouchDB isn't lying about having saved your document (it
-usually doesn't), try to retrieve it by sending a GET request::
+usually doesn't), try to retrieve it by sending a GET request:
+
+.. code-block:: none
 
     curl -X GET http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af
 
@@ -404,7 +452,9 @@ in case somebody else made a change without you knowing before you got to
 request the document update, CouchDB will not accept your update because you
 are likely to overwrite data you didn't know existed. Or simplified: whoever
 saves a change to a document first, wins. Let's see what happens if we don't
-provide a ``_rev`` field (which is equivalent to providing a outdated value)::
+provide a ``_rev`` field (which is equivalent to providing a outdated value):
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af \
          -d '{"title":"There is Nothing Left to Lose","artist":"Foo Fighters","year":"1997"}'
@@ -416,7 +466,9 @@ CouchDB replies:
     {"error":"conflict","reason":"Document update conflict."}
 
 If you see this, add the latest revision number of your document to the JSON
-structure::
+structure:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af \
          -d '{"_rev":"1-2902191555","title":"There is Nothing Left to Lose","artist":"Foo Fighters","year":"1997"}'
@@ -480,7 +532,9 @@ later examples.
 
 We'll add some more of our favorite music albums. Get a fresh UUID from the
 ``/_uuids`` resource. If you don't remember how that works, you can look it up
-a few pages back. ::
+a few pages back.
+
+.. code-block:: none
 
     curl -vX PUT http://127.0.0.1:5984/albums/70b50bfa0a4b3aed1f8aff9e92dc16a0 \
          -d '{"title":"Blackened Sky","artist":"Biffy Clyro","year":2002}'
@@ -493,7 +547,9 @@ a few pages back. ::
     worry about data.
 
 Now with the ``-v`` option, CouchDB's reply (with only the important bits shown)
-looks like this::
+looks like this:
+
+.. code-block:: none
 
     > PUT /albums/70b50bfa0a4b3aed1f8aff9e92dc16a0 HTTP/1.1
     >
@@ -526,7 +582,9 @@ documents, music, or movie files. Let's make one.
 Attachments get their own URL where you can upload data. Say we want to add
 the album artwork to the ``6e1295ed6c29495e54cc05947f18c8af`` document
 (*"There is Nothing Left to Lose"*), and let's also say the artwork is in a file
-`artwork.jpg` in the current directory::
+`artwork.jpg` in the current directory:
+
+.. code-block:: none
 
     curl -vX PUT http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af/artwork.jpg?rev=2-2739352689 \
          --data-binary @artwork.jpg -H "Content-Type:image/jpg"
@@ -545,7 +603,9 @@ the album artwork to the ``6e1295ed6c29495e54cc05947f18c8af`` document
 You should now see your artwork image if you point your browser to
 http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af/artwork.jpg
 
-If you request the document again, you'll see a new member::
+If you request the document again, you'll see a new member:
+
+.. code-block:: none
 
     curl http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af
 
@@ -599,11 +659,15 @@ We'll take an in-depth look at replication in the document
 First, we'll create a target database. Note that CouchDB won't automatically
 create a target database for you, and will return a replication failure if
 the target doesn't exist (likewise for the source, but that mistake isn't as
-easy to make)::
+easy to make):
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/albums-replica
 
-Now we can use the database `albums-replica` as a replication target::
+Now we can use the database `albums-replica` as a replication target:
+
+.. code-block:: none
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
          -d '{"source":"albums","target":"albums-replica"}' \
@@ -662,7 +726,9 @@ a stable version of your code and data.
 There are more types of replication useful in other situations. The source
 and target members of our replication request are actually links (like in
 HTML) and so far we've seen links relative to the server we're working on
-(hence local). You can also specify a remote database as the target::
+(hence local). You can also specify a remote database as the target:
+
+.. code-block:: none
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
          -d '{"source":"albums","target":"http://example.org:5984/albums-replica"}' \
@@ -681,14 +747,18 @@ door.
 
 You can also use a *remote source* and a *local target* to do a *pull
 replication*. This is great for getting the latest changes from a server that
-is used by others::
+is used by others:
+
+.. code-block:: none
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
          -d '{"source":"http://example.org:5984/albums-replica","target":"albums"}' \
          -H "Content-Type:application/json"
 
 Finally, you can run remote replication, which is mostly useful for management
-operations::
+operations:
+
+.. code-block:: none
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
          -d '{"source":"http://example.org:5984/albums","target":"http://example.org:5984/albums-replica"}' \

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -81,7 +81,9 @@ Creating New Admin User
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Let's do another walk through the API using `curl` to see how CouchDB behaves
-when you add admin users. ::
+when you add admin users.
+
+.. code-block:: none
 
     > HOST="http://127.0.0.1:5984"
     > curl -X PUT $HOST/database
@@ -90,7 +92,9 @@ when you add admin users. ::
 When starting out fresh, we can add a database. Nothing unexpected. Now let's
 create an admin user. We'll call her ``anna``, and her password is ``secret``.
 Note the double quotes in the following code; they are needed to denote a string
-value for the :ref:`configuration API <api/config>`::
+value for the :ref:`configuration API <api/config>`
+
+.. code-block:: none
 
     > curl -X PUT $HOST/_config/admins/anna -d '"secret"'
     ""
@@ -152,12 +156,16 @@ Basic Authentication
 --------------------
 
 Now that we have defined an admin, CouchDB will not allow us to create new
-databases unless we give the correct admin user credentials. Let's verify::
+databases unless we give the correct admin user credentials. Let's verify:
+
+.. code-block:: none
 
     > curl -X PUT $HOST/somedatabase
     {"error":"unauthorized","reason":"You are not a server admin."}
 
-That looks about right. Now we try again with the correct credentials::
+That looks about right. Now we try again with the correct credentials:
+
+.. code-block:: none
 
     > HOST="http://anna:secret@127.0.0.1:5984"
     > curl -X PUT $HOST/somedatabase
@@ -208,14 +216,18 @@ API. The API is smart enough to decode HTML form submissions, so you don't have
 to resort to any smarts in your application.
 
 If you are not using HTML forms to log in, you need to send an HTTP request
-that looks as if an HTML form generated it. Luckily, this is super simple::
+that looks as if an HTML form generated it. Luckily, this is super simple:
+
+.. code-block:: none
 
     > HOST="http://127.0.0.1:5984"
     > curl -vX POST $HOST/_session \
            -H 'Content-Type:application/x-www-form-urlencoded' \
            -d 'name=anna&password=secret'
 
-CouchDB replies, and we'll give you some more detail::
+CouchDB replies, and we'll give you some more detail:
+
+.. code-block:: none
 
     < HTTP/1.1 200 OK
     < Set-Cookie: AuthSession=YW5uYTo0QUIzOTdFQjrC4ipN-D-53hw1sJepVzcVxnriEw;
@@ -229,7 +241,9 @@ header includes the token we can use for the next request, and the standard JSON
 response tells us again that the request was successful.
 
 Now we can use this token to make another request as the same user without
-sending the username and password again::
+sending the username and password again:
+
+.. code-block:: none
 
     > curl -vX PUT $HOST/mydatabase \
            --cookie AuthSession=YW5uYTo0QUIzOTdFQjrC4ipN-D-53hw1sJepVzcVxnriEw \
@@ -322,7 +336,9 @@ Creating a New User
 
 Creating a new user is a very trivial operation. You just need to do a
 :method:`PUT` request with the user's data to CouchDB. Let's create a user with
-login `jan` and password `apple`::
+login `jan` and password `apple`:
+
+.. code-block:: none
 
     curl -X PUT http://localhost:5984/_users/org.couchdb.user:jan \
          -H "Accept: application/json" \
@@ -356,7 +372,9 @@ And CouchDB responds with:
     {"ok":true,"id":"org.couchdb.user:jan","rev":"1-e0ebfb84005b920488fc7a8cc5470cc0"}
 
 The document was successfully created! The user `jan` should now exist in our
-database. Let's check if this is true::
+database. Let's check if this is true:
+
+.. code-block:: none
 
     curl -X POST http://localhost:5984/_session -d 'name=jan&password=apple'
 
@@ -386,7 +404,9 @@ replaces it with the *secured hash* depending on the chosen ``password_scheme``.
 
 Summarizing the above process - we need to get the document's content, add
 the ``password`` field with the new password in plain text and then store the
-JSON result to the authentication database. ::
+JSON result to the authentication database.
+
+.. code-block:: none
 
     curl -X GET http://localhost:5984/_users/org.couchdb.user:jan
 
@@ -405,7 +425,9 @@ JSON result to the authentication database. ::
     }
 
 Here is our user's document. We may strip hashes from the stored document to
-reduce the amount of posted data::
+reduce the amount of posted data:
+
+.. code-block:: none
 
     curl -X PUT http://localhost:5984/_users/org.couchdb.user:jan \
          -H "Accept: application/json" \
@@ -417,7 +439,9 @@ reduce the amount of posted data::
 
     {"ok":true,"id":"org.couchdb.user:jan","rev":"2-ed293d3a0ae09f0c624f10538ef33c6f"}
 
-Updated! Now let's check that the password was really changed::
+Updated! Now let's check that the password was really changed:
+
+.. code-block:: none
 
     curl -X POST http://localhost:5984/_session -d 'name=jan&password=apple'
 
@@ -427,7 +451,9 @@ CouchDB should respond with:
 
     {"error":"unauthorized","reason":"Name or password is incorrect."}
 
-Looks like the password ``apple`` is wrong, what about ``orange``? ::
+Looks like the password ``apple`` is wrong, what about ``orange``?
+
+.. code-block:: none
 
     curl -X POST http://localhost:5984/_session -d 'name=jan&password=orange'
 
@@ -461,7 +487,9 @@ a special :ref:`configuration <config>` option :config:option:`public_fields
 a comma-separated list of users document fields that will be publicly available.
 
 Normally, if you request a user document and you're not an administrator or the
-document's owner, CouchDB will respond with :statuscode:`404`::
+document's owner, CouchDB will respond with :statuscode:`404`:
+
+.. code-block:: none
 
     curl http://localhost:5984/_users/org.couchdb.user:robert
 
@@ -481,7 +509,9 @@ privileges. The next command will prompt you for user `admin`'s password:
        -d '"name"' \
        -u admin
 
-What has changed? Let's check Robert's document once again::
+What has changed? Let's check Robert's document once again:
+
+.. code-block:: none
 
     curl http://localhost:5984/_users/org.couchdb.user:robert
 
@@ -518,7 +548,9 @@ When a database is first created, there are no members or admins.  HTTP
 requests that have no authentication credentials or have credentials for a
 normal user are treated as members, and those with server admin credentials
 are treated as database admins.  To change the default permissions, you must
-create a :ref:`_security <api/db/security>` document in the database::
+create a :ref:`_security <api/db/security>` document in the database:
+
+.. code-block:: none
 
     > curl -X PUT http://localhost:5984/mydatabase/_security \
          -u anna:secret \
@@ -532,7 +564,9 @@ credentials of a server admin.  CouchDB will respond with:
 
     {"ok":true}
 
-The database is now secured against anonymous reads and writes::
+The database is now secured against anonymous reads and writes:
+
+.. code-block:: none
 
     > curl http://localhost:5984/mydatabase/
 
@@ -541,7 +575,9 @@ The database is now secured against anonymous reads and writes::
     {"error":"unauthorized","reason":"You are not authorized to access this db."}
 
 You declared user "jan" as a member in this database, so he is able to read and
-write normal documents::
+write normal documents:
+
+.. code-block:: none
 
     > curl -u jan:apple http://localhost:5984/mydatabase/
 
@@ -559,7 +595,9 @@ Jan to an admin, you can update the security document to add `"jan"` to
 the `names` array under `admin`.  Keeping track of individual database
 admin usernames is tedious, though, so you would likely prefer to create a
 database admin role and assign that role to the `org.couchdb.user:jan` user
-document::
+document:
+
+.. code-block:: none
 
     > curl -X PUT http://localhost:5984/mydatabase/_security \
          -u anna:secret \

--- a/src/intro/tour.rst
+++ b/src/intro/tour.rst
@@ -30,7 +30,9 @@ throughout the rest of the documents. What's interesting about curl is that it
 gives you control over raw HTTP requests, and you can see exactly what is
 going on "underneath the hood" of your database.
 
-Make sure CouchDB is still running, and then do::
+Make sure CouchDB is still running, and then do:
+
+.. code-block:: none
 
     curl http://127.0.0.1:5984/
 
@@ -53,7 +55,9 @@ The reply should look something like:
 Not all that spectacular. CouchDB is saying "hello" with the running version
 number.
 
-Next, we can get a list of databases::
+Next, we can get a list of databases:
+
+.. code-block:: none
 
     curl -X GET http://127.0.0.1:5984/_all_dbs
 
@@ -78,7 +82,9 @@ list.
     the server curl tries to connect to, the request headers it sends,
     and response headers it receives back. Great for debugging!
 
-Let's create a database::
+Let's create a database:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/baseball
 
@@ -86,7 +92,9 @@ CouchDB will reply with::
 
     {"ok":true}
 
-Retrieving the list of databases again shows some useful results this time::
+Retrieving the list of databases again shows some useful results this time:
+
+.. code-block:: none
 
     curl -X GET http://127.0.0.1:5984/_all_dbs
 
@@ -106,7 +114,9 @@ Retrieving the list of databases again shows some useful results this time::
     dictionaries. For a more detailed description of JSON, see Appendix E, JSON
     Primer.
 
-Let's create another database::
+Let's create another database:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/baseball
 
@@ -116,7 +126,9 @@ CouchDB will reply with::
     the file already exists."}
 
 We already have a database with that name, so CouchDB will respond with an
-error. Let's try again with a different database name::
+error. Let's try again with a different database name:
+
+.. code-block:: none
 
     curl -X PUT http://127.0.0.1:5984/plankton
 
@@ -124,7 +136,9 @@ CouchDB will reply with::
 
     {"ok":true}
 
-Retrieving the list of databases yet again shows some useful results::
+Retrieving the list of databases yet again shows some useful results:
+
+.. code-block:: none
 
     curl -X GET http://127.0.0.1:5984/_all_dbs
 
@@ -132,7 +146,9 @@ CouchDB will respond with::
 
     ["baseball", "plankton"]
 
-To round things off, let's delete the second database::
+To round things off, let's delete the second database:
+
+.. code-block:: none
 
     curl -X DELETE http://127.0.0.1:5984/plankton
 
@@ -140,7 +156,9 @@ CouchDB will reply with::
 
     {"ok":true}
 
-The list of databases is now the same as it was before::
+The list of databases is now the same as it was before:
+
+.. code-block:: none
 
     curl -X GET http://127.0.0.1:5984/_all_dbs
 
@@ -165,7 +183,9 @@ complex ideas involved. With Futon we can create and destroy databases; view
 and edit documents; compose and run MapReduce views; and trigger replication
 between databases.
 
-To load Futon in your browser, visit::
+To load Futon in your browser, visit:
+
+.. code-block:: none
 
     http://127.0.0.1:5984/_utils/
 

--- a/src/intro/why.rst
+++ b/src/intro/why.rst
@@ -31,7 +31,9 @@ Relax
 =====
 
 If there's one word to describe CouchDB, it is *relax*. It is the byline
-to CouchDB's official logo and when you start CouchDB, you see::
+to CouchDB's official logo and when you start CouchDB, you see:
+
+.. code-block:: none
 
     Apache CouchDB has started. Time to relax.
 

--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -45,7 +45,9 @@ resolution during replication. The number of stored revisions
 
 Compaction is manually triggered operation per database and runs as a background
 task. To start it for specific database there is need to send HTTP
-:post:`/{db}/_compact` sub-resource of the target database::
+:post:`/{db}/_compact` sub-resource of the target database:
+
+.. code-block:: none
 
     curl -H "Content-Type: application/json" -X POST http://localhost:5984/my_db/_compact
 
@@ -81,7 +83,9 @@ for the request. If you don't, you will be aware about with HTTP status
     {"error":"bad_content_type","reason":"Content-Type must be application/json"}
 
 When the compaction is successful started and running it is possible to get
-information about it via :ref:`database information resource <api/db>`::
+information about it via :ref:`database information resource <api/db>`:
+
+.. code-block:: none
 
     curl http://localhost:5984/my_db
 
@@ -110,7 +114,9 @@ information about it via :ref:`database information resource <api/db>`::
 
 Note that ``compaction_running`` field is ``true`` indicating that compaction
 is actually running. To track the compaction progress you may query the
-:get:`_active_tasks </_active_tasks>` resource::
+:get:`_active_tasks </_active_tasks>` resource:
+
+.. code-block:: none
 
     curl http://localhost:5984/my_db
 
@@ -143,7 +149,9 @@ Views Compaction
 
 `Views` are also need compaction like databases, unlike databases views
 are compacted by groups per `design document`. To start their compaction there
-is need to send HTTP :post:`/{db}/_compact/{ddoc}` request::
+is need to send HTTP :post:`/{db}/_compact/{ddoc}` request:
+
+.. code-block:: none
 
     curl -H "Content-Type: application/json" -X POST http://localhost:5984/dbname/_compact/designname
 
@@ -164,7 +172,9 @@ Views cleanup
 View indexes on disk are named after their `MD5` hash of the view definition.
 When you change a view, old indexes remain on disk. To clean up all outdated
 view indexes (files named after the MD5 representation of views, that does not
-exist anymore) you can trigger a :ref:`view cleanup <api/db/view_cleanup>`::
+exist anymore) you can trigger a :ref:`view cleanup <api/db/view_cleanup>`:
+
+.. code-block:: none
 
     curl -H "Content-Type: application/json" -X POST http://localhost:5984/dbname/_view_cleanup
 

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -52,7 +52,9 @@ installation responsive even during periods of heavy disk utilization. The
 easiest way to set this option is through the ``ERL_FLAGS`` environment
 variable. For example, to give Erlang four threads with which to perform I/O
 operations add the following to ``(prefix)/etc/defaults/couchdb``
-(or equivalent)::
+(or equivalent):
+
+.. code-block:: none
 
     export ERL_FLAGS="+A 4"
 
@@ -102,7 +104,9 @@ Erlang
 Even if you've increased the maximum connections CouchDB will allow,
 the Erlang runtime system will not allow more than 1024 connections by
 default. Adding the following directive to ``(prefix)/etc/default/couchdb`` (or
-equivalent) will increase this limit (in this case to 4096)::
+equivalent) will increase this limit (in this case to 4096):
+
+.. code-block:: none
 
     export ERL_MAX_PORTS=4096
 
@@ -128,7 +132,9 @@ process. If your system is set up to use the Pluggable Authentication Modules
 (`PAM`_) system, increasing this limit is straightforward. For example,
 creating a file named ``/etc/security/limits.d/100-couchdb.conf`` with the
 following contents will ensure that CouchDB can open enough file descriptors
-to service your increased maximum open databases and Erlang ports::
+to service your increased maximum open databases and Erlang ports:
+
+.. code-block:: none
 
     #<domain>    <type>    <item>    <value>
     couchdb      hard      nofile    4096

--- a/src/query-server/protocol.rst
+++ b/src/query-server/protocol.rst
@@ -432,14 +432,18 @@ Executes :ref:`list function <listfun>`.
 The communication protocol for `list` functions is a bit complex so let's use
 an example for illustration.
 
-Let's assume that we have view a function that emits `id-rev` pairs::
+Let's assume that we have view a function that emits `id-rev` pairs:
+
+.. code-block:: javascript
 
     function(doc) {
         emit(doc._id, doc._rev);
     }
 
 And we'd like to emulate ``_all_docs`` JSON response with list function. Our
-*first* version of the list functions looks like this::
+*first* version of the list functions looks like this:
+
+.. code-block:: javascript
 
     function(head, req){
         start({'headers': {'Content-Type': 'application/json'}});
@@ -457,7 +461,9 @@ on three parts:
 
 #. Initialization
 
-   The first returned object from list function is an array of next structure::
+   The first returned object from list function is an array of next structure:
+
+   .. code-block:: none
 
        ["start", <chunks>, <headers>]
 
@@ -531,7 +537,9 @@ message from the Query Server. That's ok when there are only a few rows in the
 view result, but it's not acceptable for millions documents and millions view
 rows
 
-Let's fix our list function and see the changes in communication::
+Let's fix our list function and see the changes in communication:
+
+.. code-block:: javascript
 
     function(head, req){
         start({'headers': {'Content-Type': 'application/json'}});
@@ -550,7 +558,9 @@ Let's fix our list function and see the changes in communication::
     }
 
 "Wait, what?" - you'd like to ask. Yes, we'd build JSON response manually by
-string chunks, but let's take a look on logs::
+string chunks, but let's take a look on logs:
+
+.. code-block:: none
 
     [Wed, 24 Jul 2013 05:45:30 GMT] [debug] [<0.19191.1>] OS Process #Port<0.4444> Output :: ["start",["{","\"total_rows\":2,","\"offset\":0,","\"rows\":["],{"headers":{"Content-Type":"application/json"}}]
     [Wed, 24 Jul 2013 05:45:30 GMT] [info] [<0.18963.1>] 127.0.0.1 - - GET /blog/_design/post/_list/index/all_docs 200
@@ -1039,7 +1049,9 @@ field, log, on a separate line::
 
     ["log", "some message"]
 
-CouchDB responds nothing, but writes received message into log file::
+CouchDB responds nothing, but writes received message into log file:
+
+.. code-block:: none
 
     [Sun, 13 Feb 2009 23:31:30 GMT] [info] [<0.72.0>] Query Server Log Message: some message
 

--- a/src/replication/conflicts.rst
+++ b/src/replication/conflicts.rst
@@ -174,7 +174,7 @@ write any code for the possibility of getting a 409 response, because you will
 never get one. Rather, you have to deal with conflicts appearing later in the
 database, which is what you'd have to do in a multi-master application anyway.
 
-.. code-block:: http
+.. code-block:: none
 
     POST /db/_bulk_docs
 
@@ -525,7 +525,9 @@ of the previous revision ids which ended up with revision v2b. Doing the same
 for v2a you can find their common ancestor revision. However if the database
 has been compacted, the content of that document revision will have been lost.
 ``revs_info`` will still show that v1 was an ancestor, but report it as
-"missing"::
+"missing":
+
+.. code-block:: none
 
     BEFORE COMPACTION           AFTER COMPACTION
 
@@ -597,7 +599,9 @@ actually an SHA1 hash of the tip commit.
 .. _Git: http://git-scm.com/
 
 If you are replicating with one or more peers, a separate branch is made for
-each of the peers. For example, you might have::
+each of the peers. For example, you might have:
+
+.. code-block:: none
 
     master               -- my local branch
     remotes/foo/master   -- branch on peer 'foo'
@@ -610,7 +614,9 @@ attempt to "merge" those changes into the local branch.
 
 Now let's consider the business card. Alice has created a git repo containing
 ``bob.vcf``, and cloned it across to the other machine. The branches look like
-this, where ``AAAAAAAA`` is the SHA1 of the commit::
+this, where ``AAAAAAAA`` is the SHA1 of the commit:
+
+.. code-block:: none
 
     ---------- desktop ----------           ---------- laptop ----------
     master: AAAAAAAA                        master: AAAAAAAA
@@ -618,7 +624,9 @@ this, where ``AAAAAAAA`` is the SHA1 of the commit::
 
 Now she makes a change on the desktop, and commits it into the desktop repo;
 then she makes a different change on the laptop, and commits it into the laptop
-repo::
+repo:
+
+.. code-block:: none
 
     ---------- desktop ----------           ---------- laptop ----------
     master: BBBBBBBB                        master: CCCCCCCC
@@ -626,7 +634,9 @@ repo::
 
 Now on the desktop she does ``git pull laptop``. Firstly, the remote objects
 are copied across into the local repo and the remote tracking branch is
-updated::
+updated:
+
+.. code-block:: none
 
     ---------- desktop ----------           ---------- laptop ----------
     master: BBBBBBBB                        master: CCCCCCCC
@@ -640,14 +650,18 @@ Then git will attempt to merge the changes in. It can do this because it knows
 the parent commit to ``CCCCCCCC`` is ``AAAAAAAA``, so it takes a diff between
 ``AAAAAAAA`` and ``CCCCCCCC`` and tries to apply it to ``BBBBBBBB``.
 
-If this is successful, then you'll get a new version with a merge commit::
+If this is successful, then you'll get a new version with a merge commit:
+
+.. code-block:: none
 
     ---------- desktop ----------           ---------- laptop ----------
     master: DDDDDDDD                        master: CCCCCCCC
     remotes/laptop/master: CCCCCCCC         remotes/desktop/master: AAAAAAAA
 
 Then Alice has to logon to the laptop and run ``git pull desktop``. A similar
-process occurs. The remote tracking branch is updated::
+process occurs. The remote tracking branch is updated:
+
+.. code-block:: none
 
     ---------- desktop ----------           ---------- laptop ----------
     master: DDDDDDDD                        master: CCCCCCCC
@@ -656,7 +670,9 @@ process occurs. The remote tracking branch is updated::
 Then a merge takes place. This is a special-case: ``CCCCCCCC`` one of the parent
 commits of ``DDDDDDDD``, so the laptop can `fast forward` update from
 ``CCCCCCCC`` to ``DDDDDDDD`` directly without having to do any complex merging.
-This leaves the final state as::
+This leaves the final state as:
+
+.. code-block:: none
 
     ---------- desktop ----------           ---------- laptop ----------
     master: DDDDDDDD                        master: DDDDDDDD
@@ -680,7 +696,9 @@ work well for XML or JSON if it's presented without any line breaks.
 The other interesting consideration is multiple peers. In this case you have
 multiple remote tracking branches, some of which may match your local branch,
 some of which may be behind you, and some of which may be ahead of you
-(i.e. contain changes that you haven't yet merged)::
+(i.e. contain changes that you haven't yet merged):
+
+.. code-block:: none
 
     master: AAAAAAAA
     remotes/foo/master: BBBBBBBB

--- a/src/whatsnew/0.10.rst
+++ b/src/whatsnew/0.10.rst
@@ -40,7 +40,9 @@ in order:
 - PREFIX/local.ini
 - PREFIX/local.d/*
 
-The configuration options for `couchdb` script have changed to::
+The configuration options for `couchdb` script have changed to:
+
+.. code-block:: none
 
   -a FILE     add configuration FILE to chain
   -A DIR      add configuration DIR to chain

--- a/src/whatsnew/0.9.rst
+++ b/src/whatsnew/0.9.rst
@@ -59,11 +59,15 @@ Moved View URLs
 ---------------
 
 The view URLs have been moved to design document resources. This means that
-paths that used to be like::
+paths that used to be like:
+
+.. code-block:: none
 
     http://hostname:5984/mydb/_view/designname/viewname?limit=10
 
-will now look like::
+will now look like:
+
+.. code-block:: none
 
     http://hostname:5984/mydb/_design/designname/_view/viewname?limit=10.
 


### PR DESCRIPTION
Our documentation has been moved to its own
repository, couchdb-documentation, and some of 
the details for getting into it have changed.

For the example, I replaced Jan's username with 
my own, as using his would have been a 404, and 
using mine seemed like the next-best idea.
