### PR TITLE
Ignore Python3 __pycache__ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 ext/*.pyc
+ext/__pycache__/
 build/
-


### PR DESCRIPTION
A `__pycache__` directory appeared after making the docs with a Python3 version of Sphinx. Python3 stores cache files in that directory instead of *.pyc files. Should be added to .gitignore.