### PR TITLE
COUCHDB-3068 - Fixes to make docs build with Sphinx 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install -yqq texinfo
 
 install:
-  - pip install sphinx==1.3.4
+  - pip install sphinx
 
 script:
   - make ${TARGET}

--- a/ext/httpdomain.py
+++ b/ext/httpdomain.py
@@ -650,7 +650,4 @@ class HTTPLexer(RegexLexer):
 
 def setup(app):
     app.add_domain(HTTPDomain)
-    try:
-        get_lexer_by_name('http')
-    except ClassNotFound:
-        app.add_lexer('http', HTTPLexer())
+    app.add_lexer('http', HTTPLexer())

--- a/src/api/basics.rst
+++ b/src/api/basics.rst
@@ -143,6 +143,7 @@ Request Headers
 
   .. code-block:: http
 
+      HTTP/1.1 200 OK
       Server: CouchDB (Erlang/OTP)
       Date: Thu, 13 Jan 2011 13:39:34 GMT
       Content-Type: text/plain;charset=utf-8
@@ -165,6 +166,7 @@ Request Headers
 
   .. code-block:: http
 
+      HTTP/1.1 200 OK
       Server: CouchDB (Erlang/OTP)
       Date: Thu, 13 Jan 2013 13:40:11 GMT
       Content-Type: application/json

--- a/src/api/database/changes.rst
+++ b/src/api/database/changes.rst
@@ -434,7 +434,7 @@ to the ``filter`` parameter, specifying the design document name and
 
 .. code-block:: http
 
-    GET /db/_changes?filter=design_doc/filtername
+    GET /db/_changes?filter=design_doc/filtername HTTP/1.1
 
 Additionally, there are couple of builtin filters are available and described
 below.

--- a/src/api/database/index.rst
+++ b/src/api/database/index.rst
@@ -24,13 +24,13 @@ should be the database name that you wish to perform the operation on.
 For example, to obtain the meta information for the database
 ``recipes``, you would use the HTTP request:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /recipes
 
 For clarity, the form below is used in the URL paths:
 
-.. code-block:: http
+.. code-block:: none
 
     GET /db
 

--- a/src/api/ddoc/render.rst
+++ b/src/api/ddoc/render.rst
@@ -312,7 +312,7 @@
         Content-Type: application/json
         Host: localhost:5984
 
-        something
+        "something"
 
     **Response**:
 
@@ -377,7 +377,7 @@
         Content-Type: application/json
         Host: localhost:5984
 
-        love
+        "love"
 
     **Response**:
 

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -581,7 +581,7 @@ The sorting direction is applied before the filtering applied using the
 
 .. code-block:: http
 
-    GET http://couchdb:5984/recipes/_design/recipes/_view/by_ingredient?startkey=%22carrots%22&endkey=%22egg%22
+    GET http://couchdb:5984/recipes/_design/recipes/_view/by_ingredient?startkey=%22carrots%22&endkey=%22egg%22 HTTP/1.1
     Accept: application/json
 
 will operate correctly when listing all the matching entries between

--- a/src/api/document/common.rst
+++ b/src/api/document/common.rst
@@ -359,7 +359,7 @@
 
     **Request**:
 
-    .. code-block:: http
+    .. code-block:: none
 
         COPY /recipes/SpaghettiWithMeatballs HTTP/1.1
         Accept: application/json
@@ -1131,7 +1131,7 @@ or :header:`If-Match`:
 
 **Request**:
 
-.. code-block:: http
+.. code-block:: none
 
     COPY /recipes/SpaghettiWithMeatballs HTTP/1.1
     Accept: application/json
@@ -1167,7 +1167,7 @@ for the target document by appending the ``rev`` parameter to the
 
 **Request**:
 
-.. code-block:: http
+.. code-block:: none
 
     COPY /recipes/SpaghettiWithMeatballs?rev=8-6f5ad8db0f34af24a6e0984cd1a6cfb9 HTTP/1.1
     Accept: application/json

--- a/src/api/document/common.rst
+++ b/src/api/document/common.rst
@@ -359,7 +359,7 @@
 
     **Request**:
 
-    .. code-block:: none
+    .. code-block:: http
 
         COPY /recipes/SpaghettiWithMeatballs HTTP/1.1
         Accept: application/json
@@ -1131,7 +1131,7 @@ or :header:`If-Match`:
 
 **Request**:
 
-.. code-block:: none
+.. code-block:: http
 
     COPY /recipes/SpaghettiWithMeatballs HTTP/1.1
     Accept: application/json
@@ -1167,7 +1167,7 @@ for the target document by appending the ``rev`` parameter to the
 
 **Request**:
 
-.. code-block:: none
+.. code-block:: http
 
     COPY /recipes/SpaghettiWithMeatballs?rev=8-6f5ad8db0f34af24a6e0984cd1a6cfb9 HTTP/1.1
     Accept: application/json

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -367,7 +367,7 @@ counted back from the end. For example, if you use the following request:
 
 .. code-block:: http
 
-    GET /_log?bytes=500&offset=2000
+    GET /_log?bytes=500&offset=2000 HTTP/1.1
 
 Reading of the log will start at 2000 bytes from the end of the log, and 500
 bytes will be shown.
@@ -551,7 +551,7 @@ following request:
 
 .. code-block:: http
 
-    POST http://couchdb:5984/_replicate
+    POST http://couchdb:5984/_replicate HTTP/1.1
     Content-Type: application/json
     Accept: application/json
 
@@ -576,7 +576,7 @@ by adding the ``create_target`` field to the request object:
 
 .. code-block:: http
 
-    POST http://couchdb:5984/_replicate
+    POST http://couchdb:5984/_replicate HTTP/1.1
     Content-Type: application/json
     Accept: application/json
 
@@ -600,7 +600,7 @@ synchronization between two databases by supplying the ``source`` and
 
 .. code-block:: http
 
-    POST http://couchdb:5984/_replicate
+    POST http://couchdb:5984/_replicate HTTP/1.1
     Accept: application/json
     Content-Type: application/json
 
@@ -651,7 +651,7 @@ replication ceases.
 
 .. code-block:: http
 
-    POST http://couchdb:5984/_replicate
+    POST http://couchdb:5984/_replicate HTTP/1.1
     Accept: application/json
     Content-Type: application/json
 
@@ -682,7 +682,7 @@ For example, the replication request:
 
 .. code-block:: http
 
-    POST http://couchdb:5984/_replicate
+    POST http://couchdb:5984/_replicate HTTP/1.1
     Content-Type: application/json
     Accept: application/json
 
@@ -697,7 +697,7 @@ Must be canceled using the request:
 
 .. code-block:: http
 
-    POST http://couchdb:5984/_replicate
+    POST http://couchdb:5984/_replicate HTTP/1.1
     Accept: application/json
     Content-Type: application/json
 
@@ -921,7 +921,7 @@ and statistic ID as part of the URL path. For example, to get the
 
 .. code-block:: http
 
-    GET /_stats/couchdb/request_time
+    GET /_stats/couchdb/request_time HTTP/1.1
 
 This returns an entire statistics object, as with the full request, but
 containing only the request individual statistic. Hence, the returned structure
@@ -1033,7 +1033,7 @@ could be changed to ``random`` by sending this HTTP request:
 
 .. code-block:: http
 
-    PUT http://couchdb:5984/_config/uuids/algorithm
+    PUT http://couchdb:5984/_config/uuids/algorithm HTTP/1.1
     Content-Type: application/json
     Accept: */*
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -36,8 +36,6 @@ copyright = '%d, %s' % (
     'Apache Software Foundation'
 )
 
-highlight_language = "json"
-
 primary_domain = "http"
 
 pygments_style = "sphinx"

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -17,7 +17,7 @@
 Compaction Configuration
 ========================
 
-.. _conifg/database_compaction:
+.. _config/database_compaction:
 
 Database Compaction Options
 ===========================

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -111,26 +111,38 @@ Compaction Daemon Rules
 
     Examples:
 
-    #. ``[{db_fragmentation, "70%"}, {view_fragmentation, "60%"}]``
+    #.
+        ::
+
+            [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}]
 
        The `foo` database is compacted if its fragmentation is 70% or more. Any
        view index of this database is compacted only if its fragmentation is
        60% or more.
 
-    #. ``[{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "00:00"}, {to, "04:00"}]``
+    #.
+        ::
+
+            [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "00:00"}, {to, "04:00"}]
 
        Similar to the preceding example but a compaction (database or view
        index) is only triggered if the current time is between midnight and 4
        AM.
 
-    #. ``[{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "00:00"}, {to, "04:00"}, {strict_window, true}]``
+    #.
+        ::
+
+            [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "00:00"}, {to, "04:00"}, {strict_window, true}]
 
        Similar to the preceding example - a compaction (database or view index)
        is only triggered if the current time is between midnight and 4 AM. If
        at 4 AM the database or one of its views is still compacting, the
        compaction process will be canceled.
 
-    #. ``[{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "00:00"}, {to, "04:00"}, {strict_window, true}, {parallel_view_compaction, true}]``
+    #.
+        ::
+
+            [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "00:00"}, {to, "04:00"}, {strict_window, true}, {parallel_view_compaction, true}]
 
        Similar to the preceding example, but a database and its views can be
        compacted in parallel.

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -63,9 +63,11 @@ Compaction Daemon Rules
     - ``db_fragmentation``: If the ratio of legacy data, including metadata, to
       current data in the database file size is equal to or greater than this
       value, this condition is satisfied. The percentage is expressed as an
-      integer percentage. This value is computed as::
+      integer percentage. This value is computed as:
 
-        (file_size - data_size) / file_size * 100
+      .. code-block:: none
+
+          (file_size - data_size) / file_size * 100
 
       The data_size and file_size values can be obtained when
       querying :http:get:`/{db}`.
@@ -74,7 +76,9 @@ Compaction Daemon Rules
       to current data in a view index file size is equal to or greater then
       this value, this database compaction condition is satisfied. The
       percentage is expressed as an integer percentage. This value is computed
-      as::
+      as:
+
+      .. code-block:: none
 
           (file_size - data_size) / file_size * 100
 
@@ -83,7 +87,9 @@ Compaction Daemon Rules
 
     - ``from`` and ``to``: The period for which a database (and its view group)
       compaction is allowed. The value for these parameters must obey the
-      format::
+      format:
+
+      .. code-block:: none
 
           HH:MM - HH:MM  (HH in [0..23], MM in [0..59])
 

--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -182,7 +182,10 @@ Base CouchDB Options
         It is expected that the administrator has configured a load balancer
         in front of the CouchDB nodes in the cluster. This load balancer should
         use the /_up endpoint to determine whether or not to send HTTP requests
-        to any particular node. For HAProxy, the following config is appropriate ::
+        to any particular node. For HAProxy, the following config is
+        appropriate:
+
+        .. code-block:: none
 
           http-check disable-on-404
           option httpchk GET /_up

--- a/src/config/externals.rst
+++ b/src/config/externals.rst
@@ -43,19 +43,27 @@ OS Daemons
 
     This will make CouchDB bring up the command and attempt to keep it alive.
     To request a configuration parameter, an `os_daemon` can write a simple
-    JSON message to stdout like such::
+    JSON message to stdout like such:
+
+    .. code-block:: none
 
         ["get", "os_daemons"]\n
 
-    which would return::
+    which would return:
+
+    .. code-block:: none
 
         {"daemon_name": "/path/to/command -with args"}\n
 
-    Or::
+    Or:
+
+    .. code-block:: none
 
         ["get", "os_daemons", "daemon_name"]\n
 
-    which would return::
+    which would return:
+
+    .. code-block:: none
 
         "/path/to/command -with args"\n
 
@@ -63,26 +71,34 @@ OS Daemons
     also no method for altering the configuration.
 
     If you would like your OS daemon to be restarted in the event that the
-    configuration changes, you can send the following messages::
+    configuration changes, you can send the following messages:
+
+    .. code-block:: none
 
         ["register", $(SECTION)]\n
 
     When anything in that section changes, your OS process will be rebooted so
     it can pick up the new configuration settings. If you want to listen for
-    changes on a specific key, you can send something like::
+    changes on a specific key, you can send something like:
+
+    .. code-block:: none
 
         ["register", $(SECTION), $(KEY)]\n
 
     In this case, CouchDB will only restart your daemon if that exact
     section/key pair changes, instead of anything in that entire section.
 
-    Logging commands look like::
+    Logging commands look like:
+
+    .. code-block:: none
 
         ["log", $(JSON_MESSAGE)]\n
 
     Where ``$(JSON_MESSAGE)`` is arbitrary JSON data. These messages are logged
     at the 'info' level. If you want to log at a different level you can pass
-    messages like such::
+    messages like such:
+
+    .. code-block:: none
 
         ["log", $(JSON_MESSAGE), {"level": $(LEVEL)}]\n
 

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -274,7 +274,7 @@ Secure Socket Level Options
     Now start (or restart) CouchDB. You should be able to connect to it
     using HTTPS on port 6984:
 
-    .. code-block:: bash
+    .. code-block:: console
 
         shell> curl https://127.0.0.1:6984/
         curl: (60) SSL certificate problem, verify that the CA cert is OK. Details:
@@ -297,7 +297,7 @@ Secure Socket Level Options
     notifies you. Luckily you trust yourself (don't you?) and you can specify
     the ``-k`` option as the message reads:
 
-    .. code-block:: bash
+    .. code-block:: console
 
         shell> curl -k https://127.0.0.1:6984/
         {"couchdb":"Welcome","version":"1.5.0"}

--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -11,7 +11,6 @@
 .. the License.
 
 .. default-domain:: config
-.. highlight:: ini
 .. _config/intro:
 
 =============================
@@ -42,6 +41,8 @@ The ``LOCALCONFDIR`` points to the directory that contains configuration files
 target operation system and may be changed during building from the source
 code. For binary distributions, it mostly points to the installation path
 (e.g. ``C:\Program Files\CouchDB\etc\couchdb`` for Windows).
+
+.. highlight:: shell
 
 To see the actual configuration files chain run in shell::
 
@@ -104,6 +105,8 @@ The common way to set some parameters is to edit the `local.ini` file which is
 mostly located in the `etc/couchdb` directory relative your installation path
 root.
 
+.. highlight:: ini
+
 For example::
 
     ; This is a comment
@@ -142,6 +145,8 @@ to apply these changes.
 
 Setting parameters via the HTTP API
 ===================================
+
+.. highlight:: shell
 
 Alternatively, configuration parameters could be set via the
 :ref:`HTTP API <api/config>`. This API allows to change CouchDB configuration

--- a/src/replication/conflicts.rst
+++ b/src/replication/conflicts.rst
@@ -176,7 +176,7 @@ database, which is what you'd have to do in a multi-master application anyway.
 
 .. code-block:: http
 
-    POST /db/_bulk_docs
+    POST /db/_bulk_docs HTTP/1.1
 
 .. code-block:: javascript
 


### PR DESCRIPTION
* Remove JSON as default highlight language from conf.py, so Sphinx does not assume all non-marked code blocks are JSON per default.
* Use valid HTTP
  * add ` HTTP/1.1` to each request line
  * Pygments' http lexer currently does not recognize the COPY method, so disable highlighting for blocks that use COPY.
* Minor changes with shell code-blocks - shell-sessions and shell-scripts require different lexers.