### PR TITLE
Use the proper location for `require` example

### DIFF
--- a/src/query-server/javascript.rst
+++ b/src/query-server/javascript.rst
@@ -266,7 +266,7 @@ The CommonJS module can be added to a design document, like so:
             }
         },
         "validate_doc_update": "function(newdoc, olddoc, userctx, secobj) {
-            user = require('lib/security').user(userctx, secobj);
+            user = require('views/lib/security').user(userctx, secobj);
             return user.is_admin();
         }"
         "_id": "_design/test"


### PR DESCRIPTION
The query server only copies `lib` if they are inside `views`, but `require` does start at the root of the design document.
Using `lib/security` would mean that there is a `lib` entry at the root of the design document.
