### PR TITLE
Document users db suffix

### DIFF
--- a/src/api/server/configuration.rst
+++ b/src/api/server/configuration.rst
@@ -62,12 +62,12 @@ the various configuration values within a running CouchDB instance.
             },
             "couch_httpd_auth": {
                 "auth_cache_size": "50",
-                "authentication_db": "_users",
                 "authentication_redirect": "/_utils/session.html",
                 "require_valid_user": "false",
                 "timeout": "600"
             },
             "couchdb": {
+                "users_db_suffix": "_users",
                 "database_dir": "/var/lib/couchdb",
                 "delayed_commits": "true",
                 "max_attachment_chunk_size": "4294967296",

--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -177,7 +177,7 @@ Authentication Configuration
         .. versionadded:: 1.4
 
         A comma-separated list of field names in user documents (in
-        :option:`couch_httpd_auth/authentication_db`) that can be read by any
+        :option:`couchdb/users_db_suffix`) that can be read by any
         user. If unset or not specified, authenticated users can only retrieve
         their own document. ::
 
@@ -274,7 +274,7 @@ HTTP OAuth Configuration
         use_users_db = true
 
     If set to ``true``, OAuth token and consumer secrets will be looked up in
-    the :option:`authentication database <couch_httpd_auth/authentication_db>`.
+    the :option:`authentication database <couchdb/users_db_suffix>`.
     These secrets are stored in a top level field named ``"oauth"`` in user
     documents, as below.
 

--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -123,18 +123,6 @@ Authentication Configuration
             [couch_httpd_auth]
             auth_cache_size = 50
 
-    .. config:option:: authentication_db :: Users database
-
-        Specifies the name of the system database for storing CouchDB users. ::
-
-            [couch_httpd_auth]
-            authentication_db = _users
-
-        .. warning::
-            If you change the database name, do not forget to remove or clean
-            up the old database, since it will no longer be protected by
-            CouchDB.
-
     .. config:option:: authentication_redirect :: Default redirect for authentication requests
 
         Specifies the location for redirection on successful authentication if

--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -142,6 +142,19 @@ Base CouchDB Options
 
         .. _URI: http://en.wikipedia.org/wiki/URI
 
+   .. config:option:: users_db_suffix :: Users database suffix
+
+        Specifies the suffix (last component of a name) of the system database
+        for storing CouchDB users. ::
+
+            [couchdb]
+            users_db_suffix = _users
+
+        .. warning::
+            If you change the database name, do not forget to remove or clean
+            up the old database, since it will no longer be protected by
+            CouchDB.
+
     .. config:option:: util_driver_dir :: CouchDB binary utility drivers
 
         Specifies location of binary drivers (`icu`, `ejson`, etc.). This


### PR DESCRIPTION
Introduce `couchdb/users_db_suffix` config key

Remove distinction between clustered and local users databases
configuration. We remove following configuration options and replace
them with `couchdb/users_db_suffix`:

- `chttpd_auth/authentication_db`
- `couch_httpd_auth/authentication_db`

This is a companion PR for https://github.com/apache/couchdb-couch/pull/198