### PR TITLE
Various improvements of "Installation on Unix-like systems" article

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -222,7 +222,7 @@ From here you should verify your installation by pointing your web browser to::
 
     http://localhost:5984/_utils/verify_install.html
 
-Finally, open "Configure" page and configure a cluster. After this all warning messages in a log will go away.
+Finally, `configure a cluster <http://docs.couchdb.org/en/latest/cluster/setup.html>`_ using API or web UI. After this all warning messages in a log will go away.
 
 Running as a Daemon
 ===================

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -188,31 +188,31 @@ Copy the built couchdb release to the new user's home directory::
 
 Change the ownership of the CouchDB directories by running::
 
-    chown -R couchdb:couchdb /home/couchdb/couchdb
+    chown -R couchdb:couchdb /home/couchdb
 
 Change the permission of the CouchDB directories by running::
 
-    find /home/couchdb/couchdb -type d -exec chmod 0770 {} \;
+    find /home/couchdb -type d -exec chmod 0770 {} \;
 
 Update the permissions for your ini files::
 
-    chmod 0644 /home/couchdb/couchdb/etc/*
+    chmod 0644 /home/couchdb/etc/*
 
 First Run
 =========
 
 You can start the CouchDB server by running::
 
-    sudo -i -u couchdb couchdb/bin/couchdb
+    sudo -i -u couchdb /home/couchdb/bin/couchdb
 
 This uses the ``sudo`` command to run the ``couchdb`` command as the
 ``couchdb`` user.
 
-When CouchDB starts it should eventually display the following message::
+When CouchDB starts it should eventually display following messages::
 
-    Apache CouchDB has started, time to relax.
+    {database_does_not_exist,[{mem3_shards,load_shards_from_db,"_users" ...
 
-Relax.
+Don't be afraid, we will fix this in a moment.
 
 To check that everything has worked, point your web browser to::
 
@@ -221,6 +221,8 @@ To check that everything has worked, point your web browser to::
 From here you should verify your installation by pointing your web browser to::
 
     http://localhost:5984/_utils/verify_install.html
+
+Finally, open "Configure" page and configure a cluster. After this all warning messages in a log will go away.
 
 Running as a Daemon
 ===================


### PR DESCRIPTION
1. Fix inconsistency. If user is created with --no-create-home flag, couchdb directory after `cp -R /path/to/couchdb/rel/couchdb /home/couchdb` would be /home/couchdb, not /home/couchdb/couchdb

2. Describe how to make warning messages go away.