### PR TITLE
Add documentation for compiler flags

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -134,7 +134,7 @@ To build CouchDB you should run::
 
 Try ``gmake`` if ``make`` is giving you any problems.
 
-If include paths or other compiler options must be specified, they can be passed to rebar, which compiles Couch, with the ERL_CFLAGS environment variable. Likewise, options may be passed to the linker with the ERL_LDFLAGS environment variable.::
+If include paths or other compiler options must be specified, they can be passed to rebar, which compiles Couch, with the ERL_CFLAGS environment variable. Likewise, options may be passed to the linker with the ERL_LDFLAGS environment variable::
 
     make release ERL_CFLAGS="-I/usr/local/include/js -I/usr/local/lib/erlang/usr/include"
 

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -134,7 +134,7 @@ To build CouchDB you should run::
 
 Try ``gmake`` if ``make`` is giving you any problems.
 
-If include paths or other compiler options must be specified, they can be passed to rebar, which compiles Couch, with the ERL_CFLAGS environment variable. Likewise, options may be passed to the linker with the ERL_LDFLAGS environment variable::
+If include paths or other compiler options must be specified, they can be passed to rebar, which compiles CouchDB, with the ERL_CFLAGS environment variable. Likewise, options may be passed to the linker with the ERL_LDFLAGS environment variable::
 
     make release ERL_CFLAGS="-I/usr/local/include/js -I/usr/local/lib/erlang/usr/include"
 

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -134,6 +134,10 @@ To build CouchDB you should run::
 
 Try ``gmake`` if ``make`` is giving you any problems.
 
+If include paths or other compiler options must be specified, they can be passed to rebar, which compiles Couch, with the ERL_CFLAGS environment variable. Likewise, options may be passed to the linker with the ERL_LDFLAGS environment variable.::
+
+    make release ERL_CFLAGS="-I/usr/local/include/js -I/usr/local/lib/erlang/usr/include"
+
 If everything was successful you should see the following message::
 
     ... done
@@ -301,3 +305,4 @@ Naturally now CouchDB will start automatically shortly after system starts.
 You can also configure systemd, launchd or SysV-init daemons to launch
 CouchDB and keep it running using standard configuration files. Consult
 your system documentation for more information.
+


### PR DESCRIPTION
The new build system, rebar, has non-obvious compiler flags for those used to working with a standard make/gcc build. This documents the ERL_CFLAGS and ERL_LDFLAGS environment variables.