### PR TITLE
Added location of default.ini and local.ini for macOS packaged version.

### DIFF
--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -42,7 +42,7 @@ target operation system and may be changed during building from the source
 code. For binary distributions, it mostly points to the installation path
 (e.g. ``C:\Program Files\CouchDB\etc\couchdb`` for Windows). If you are using
 the macOS packaged version, the ``default.ini`` is located in ``Applications/
-Apache\ CouchDB.app/Contents/Resources/couchdbx-core/etc`` and ``local.ini`` 
+Apache\ CouchDB.app/Contents/Resources/couchdbx-core/etc`` and ``local.ini``
 is in ``/Users/youruser/Library/Application\ Support/CouchDB2/etc/couchdb``.
 
 .. highlight:: shell

--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -40,7 +40,10 @@ The ``LOCALCONFDIR`` points to the directory that contains configuration files
 (``/usr/local/etc/couchdb`` by default). This variable may vary from the
 target operation system and may be changed during building from the source
 code. For binary distributions, it mostly points to the installation path
-(e.g. ``C:\Program Files\CouchDB\etc\couchdb`` for Windows).
+(e.g. ``C:\Program Files\CouchDB\etc\couchdb`` for Windows). If you are using
+the macOS packaged version, the ``default.ini`` is located in ``Applications/
+Apache\ CouchDB.app/Contents/Resources/couchdbx-core/etc`` and ``local.ini`` 
+is in ``/Users/youruser/Library/Application\ Support/CouchDB2/etc/couchdb``.
 
 .. highlight:: shell
 

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -234,7 +234,7 @@ run CouchDB persistently and reliably. According to official site:
 
     *runit* is a cross-platform Unix init scheme with service supervision,
     a replacement for sysvinit, and other init schemes. It runs on
-    GNU/Linux, *BSD, MacOSX, Solaris, and can easily be adapted to
+    GNU/Linux, \*BSD, MacOSX, Solaris, and can easily be adapted to
     other Unix operating systems.
 
 Configuration of runit is straightforward; if you have questions, contact


### PR DESCRIPTION
I had difficulty finding the default.ini and local.ini files for the packaged macOS version. Added it to the documentation on location of those files. 