### PR TITLE
Fix PouchDB replication source code link

### DIFF
--- a/src/replication/protocol.rst
+++ b/src/replication/protocol.rst
@@ -1283,7 +1283,7 @@ Target one by one.
     solutions MAY require a different API implementation for non-CouchDB
     Peers.
 
-.. _PouchDB: https://github.com/daleharvey/pouchdb/blob/master/src/pouch.replicate.js
+.. _PouchDB: https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-replication/src/replicate.js
 
 Upload Batch of Changed Documents
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
👋 Tiny thing, but noticed a broken link in the docs.

It might make sense to link to a specific commit blob in case the file ever moves. I'm also not 100% sure this is still the right file to link to.

It might also make sense to just link to the main project repo and let people hunt down the replication bit themselves if they're curious.