### PR TITLE
Update max_document_size description with correct semantics

### DIFF
--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -105,15 +105,21 @@ Base CouchDB Options
             [couchdb]
             max_dbs_open = 100
 
-    .. config:option:: max_document_size :: Maximum document size
+    .. config:option:: max_document_size :: Maximum HTTP request body size
 
-        .. versionchanged:: 1.3 This option now actually works.
+        .. versionchanged:: 2.0.1
 
-        Defines a maximum size for JSON documents, in bytes. This limit does
-        not apply to attachments, since they are transferred as a stream of
-        chunks. If you set this to a small value, you might be unable to modify
-        configuration options, database security and other larger documents
-        until a larger value is restored by editing the configuration file. ::
+        Even though this setting is named `max_document_size`, currently it is
+        implemented by checking HTTP request body size. For single document
+        requests the approximation is close enough, however, when multiple
+        documents are updated in a single request the discrepancy between
+        document sizes and request body size could be large. Setting this to a
+        small value might prevent replicator from writing some documents to
+        the target database or checkpointing progress. It can also prevent
+        configuring database security options. Note: up until and including
+        version 2.0 this setting was not applied to `PUT` requests with
+        multipart/related content type, which is how attachments can be
+        uploaded together with document bodies in the same request. ::
 
             [couchdb]
             max_document_size = 4294967296 ; 4 GB


### PR DESCRIPTION
`max_document_size` is a misnomer and is actually implemented as the
equivalent of `max_http_recv_body_size`. That is, it checks the total
HTTP request body size. In case of multiple documents (_bulk_docs)
or attachments, there could be a large discrepancy between the two which can
and that can be surprising for the users.

In the future we could deprecate this setting, rename it, or have an actual
check for individual document sizes, however for now it is better to inform
users of current behavior.

COUCHDB-3174