### PR TITLE
Update unix.rst

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -222,7 +222,7 @@ To check that everything has worked, point your web browser to::
 
 From here you should verify your installation by pointing your web browser to::
 
-    http://localhost:5984/_utils/verify_install.html
+    http://localhost:5984/_utils/index.html#verifyinstall
 
 Finally, to configure your cluster see :ref:`cluster/setup/wizard`.
 


### PR DESCRIPTION
Change `verify_install.html` to `index.html#verifyinstall` as `verify_install.html` does not exist (possibly due to this [change](https://github.com/apache/couchdb-documentation/blob/master/src/cve/2012-5650.rst))

The Github [README](https://github.com/apache/couchdb#verifying-your-installation) for CouchDB also suggests `http://localhost:5984/_utils/index.html#verifyinstall`