### PR TITLE
Fix os_process_limit documentation

### DIFF
--- a/src/config/query-servers.rst
+++ b/src/config/query-servers.rst
@@ -82,18 +82,19 @@ Query Servers Configuration
             [query_server_config]
             commit_freq = 5
 
-    .. config:option:: os_process_limit :: Query Server process limit
+    .. config:option:: os_process_limit :: Query Server process hard
+                       limit
 
         Hard limit on the number of OS processes usable by Query
-        Servers. The default value is ``25``::
+        Servers. The default value is ``100``::
 
             [query_server_config]
-            os_process_limit = 25
+            os_process_limit = 100
 
         Setting `os_process_limit` too low can result in starvation of
         Query Servers, and manifest in `os_process_timeout` errors,
         while setting it too high can potentially use too many system
-        resources. Production settings are typically 10-100 times the
+        resources. Production settings are typically 10-20 times the
         default value.
 
     .. config:option:: reduce_limit :: Reduce limit control

--- a/src/config/query-servers.rst
+++ b/src/config/query-servers.rst
@@ -97,6 +97,24 @@ Query Servers Configuration
         resources. Production settings are typically 10-20 times the
         default value.
 
+    .. config:option:: os_process_soft_limit :: Query Server process
+                       soft limit
+
+        Soft limit on the number of OS processes usable by Query
+        Servers. The default value is ``100``::
+
+            [query_server_config]
+            os_process_soft_limit = 100
+
+        Idle OS processes are closed until the total reaches the soft
+        limit.
+
+        For example, if the hard limit is 200 and the soft limit is
+        100, the total number of OS processes will never exceed 200,
+        and CouchDB will close all idle OS processes until it reaches
+        100, at which point it will leave the rest intact, even if
+        some are idle.
+
     .. config:option:: reduce_limit :: Reduce limit control
 
         Controls `Reduce overflow` error that raises when output of

--- a/src/config/query-servers.rst
+++ b/src/config/query-servers.rst
@@ -82,16 +82,19 @@ Query Servers Configuration
             [query_server_config]
             commit_freq = 5
 
-    .. config:option:: os_process_limit :: Query Server operation timeout
+    .. config:option:: os_process_limit :: Query Server process limit
 
-        Amount of time in seconds that the Query Server may process CouchDB
-        command::
+        Hard limit on the number of OS processes usable by Query
+        Servers. The default value is ``25``::
 
             [query_server_config]
-            os_process_limit = 10
+            os_process_limit = 25
 
-        CouchDB will raise `os_process_timeout` error and kill the process in
-        case the Query Server doesn't return any result within this limit.
+        Setting `os_process_limit` too low can result in starvation of
+        Query Servers, and manifest in `os_process_timeout` errors,
+        while setting it too high can potentially use too many system
+        resources. Production settings are typically 10-100 times the
+        default value.
 
     .. config:option:: reduce_limit :: Reduce limit control
 


### PR DESCRIPTION
Update documentation with correct description of os_process_limit
parameter function, correct default value, and hints for typical
production values.

COUCHDB-3238