### PR TITLE
Spelling error fix: fauxuton to fauxton.

### DIFF
--- a/src/intro/tour.rst
+++ b/src/intro/tour.rst
@@ -158,13 +158,13 @@ Welcome to Fauxton
 ==================
 
 After having seen CouchDB's raw API, let's get our feet wet by playing with
-Fauxuton, the built-in administration interface. Fauxuton provides full access
+Fauxton, the built-in administration interface. Fauxton provides full access
 to all of CouchDB's features and makes it easy to work with some of the more
 complex ideas involved. With Fauxton we can create and destroy databases; view
 and edit documents; compose and run MapReduce views; and trigger replication
 between databases.
 
-To load Fauxuton in your browser, visit::
+To load Fauxton in your browser, visit::
 
     http://127.0.0.1:5984/_utils/
 


### PR DESCRIPTION
I was following the intro and I spotted some spelling errors.
Moreover, why the doc intro is so updated compared to this file? http://docs.couchdb.org/en/2.0.0/intro/tour.html .. it still talks about couchdb 1.4