### PR TITLE
Update python versions to 2.7/3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - 2.6
-  - 3.3
+  - 2.7
+  - 3.4
 
 before_install:
   - sudo apt-get update -qq

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ MAKEINFO     := makeinfo
 
 BUILDDIR     := build
 SOURCE       := src/
-PAPERSIZE    := -D latex_paper_size=a4
+PAPERSIZE    := -D latex_elements.papersize=a4
 SPHINXFLAGS  := -a -W -n -A local=1 $(PAPERSIZE) -d $(BUILDDIR)/doctree
 SPHINXOPTS   := $(SPHINXFLAGS) $(SOURCE)
 

--- a/make.bat
+++ b/make.bat
@@ -7,14 +7,14 @@ if "%SPHINXBUILD%" == "" (
 )
 set BUILDDIR=build
 set SOURCE=src/
-set PAPERSIZE=-D latex_paper_size=a4
+set PAPERSIZE=-D latex_elements.papersize=a4
 set SPHINXFLAGS=-a -n -A local=1 %PAPERSIZE%
 set SPHINXOPTS=%SPHINXFLAGS% %SOURCE%
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS%
 set I18NSPHINXOPTS=%SPHINXOPTS%
 if NOT "%PAPER%" == "" (
-	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
-	set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
+	set ALLSPHINXOPTS=-D latex_elements.papersize=%PAPER% %ALLSPHINXOPTS%
+	set I18NSPHINXOPTS=-D latex_elements.papersize=%PAPER% %I18NSPHINXOPTS%
 )
 
 if "%1" == "" goto help


### PR DESCRIPTION
According to the latest failed builds, sphinx needs at least Python 2.7 or 3.4 to build.

This is simply an attempt to apply the solution suggested by sphinx. I don't know if there is any other impact to this repository - please review :)