### PR TITLE
Fix Shard documentation: typos, minor clarification on ASCII codes

### DIFF
--- a/src/cluster/sharding.rst
+++ b/src/cluster/sharding.rst
@@ -106,10 +106,10 @@ small there. Let us look in it. Yes, you can get it with curl too:
 * ``_id`` The name of the database.
 * ``_rev`` The current revision of the metadata.
 * ``shard_suffix`` The numbers after small and before .couch. The number of
-  seconds after UNIX epoch that the database was created. Stored in ASCII.
+  seconds after UNIX epoch that the database was created. This is stored as an array of ASCII codes.
 * ``changelog`` Self explaining. Only for admins to read.
 * ``by_node`` Which shards each node have.
-* ``by_rage`` On which nodes each shard is.
+* ``by_range`` On which nodes each shard is.
 
 Nothing here, nothing there, a shard in my sleeve
 -------------------------------------------------
@@ -208,7 +208,7 @@ illusion of moving. If you try to uphold this illusion with a database that have
 #. Delete the shard on the old node.
 #. Lose all writes made between 1 and 2.
 
-As the realty "I added a new replica of the shard X on node Y and then I waited
+As the reality "I added a new replica of the shard X on node Y and then I waited
 for them to sync, before I removed the replica of shard X from node Z." is a bit
 tedious, people and this documentation tend to use the illusion of moving.
 
@@ -291,7 +291,7 @@ you need to create a new cluster and migrate over.
 
 Creating more shards than you need and then move the shards around is called
 presharding. The number of shards you need depends on how much data you are
-going to store. But creating to many shards increases the complexity without any
+going to store. But, creating to many shards increases the complexity without any
 real gain. You might even get lower performance. As an example of this, we can
 take the author's (15 year) old lab server. It gets noticeably slower with more
 than one shard and high load, as the hard drive must seek more.


### PR DESCRIPTION
Just some minor typo fixes, and a clarification that might help the reader understand better that the shard_suffix is really an array of ASCII codes that amount to the UNIX timestamp.