### PR TITLE
Update references to `update_seq` to no longer claim it's always a nu…

### DIFF
--- a/src/api/ddoc/common.rst
+++ b/src/api/ddoc/common.rst
@@ -206,8 +206,8 @@ The response from :get:`/{db}/_design/{ddoc}/_info` contains
 * **language** (*string*): Language for the defined views
 * **purge_seq** (*number*): The purge sequence that has been processed
 * **signature** (*string*): MD5 signature of the views for the design document
-* **update_seq** (*number*): The update sequence of the corresponding database
-  that has been indexed
+* **update_seq** (*number* / *string*): The update sequence of the corresponding
+  database that has been indexed
 * **updater_running** (*boolean*): Indicates if the view is currently
   being updated
 * **waiting_clients** (*number*): Number of clients waiting on views from

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -99,7 +99,7 @@
     :>json array rows: Array of view row objects. By default the information
       returned contains only the document ID and revision
     :>json number total_rows: Number of documents in the database/view
-    :>json number update_seq: Current update sequence for the database
+    :>json object update_seq: Current update sequence for the database
 
     :code 200: Request completed successfully
     :code 400: Invalid request

--- a/src/json-structure.rst
+++ b/src/json-structure.rst
@@ -141,8 +141,7 @@ CouchDB database information object
 | purge_seq            | The number of purge operations on the        |
 |                      | database.                                    |
 +----------------------+----------------------------------------------+
-| update_seq           | The current number of updates made in the    |
-|                      | database.                                    |
+| update_seq           | Current update sequence for the database.    |
 +----------------------+----------------------------------------------+
 
 Design Document


### PR DESCRIPTION
…mber.

In response to the CouchDB 2.0 changes detailed here: http://docs.couchdb.org/en/master/whatsnew/2.0.html#upgrade-notes