### PR TITLE
Add documentation for the new `max_http_request_size` parameter

### DIFF
--- a/src/api/server/configuration.rst
+++ b/src/api/server/configuration.rst
@@ -72,7 +72,6 @@ the various configuration values within a running CouchDB instance.
                 "delayed_commits": "true",
                 "max_attachment_chunk_size": "4294967296",
                 "max_dbs_open": "100",
-                "max_document_size": "4294967296",
                 "os_process_timeout": "5000",
                 "uri_file": "/var/lib/couchdb/couch.uri",
                 "util_driver_dir": "/usr/lib64/couchdb/erlang/lib/couch-1.5.0/priv/lib",

--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -105,25 +105,6 @@ Base CouchDB Options
             [couchdb]
             max_dbs_open = 100
 
-    .. config:option:: max_document_size :: Maximum HTTP request body size
-
-        .. versionchanged:: 2.0.1
-
-        Even though this setting is named `max_document_size`, currently it is
-        implemented by checking HTTP request body size. For single document
-        requests the approximation is close enough, however, when multiple
-        documents are updated in a single request the discrepancy between
-        document sizes and request body size could be large. Setting this to a
-        small value might prevent replicator from writing some documents to
-        the target database or checkpointing progress. It can also prevent
-        configuring database security options. Note: up until and including
-        version 2.0 this setting was not applied to `PUT` requests with
-        multipart/related content type, which is how attachments can be
-        uploaded together with document bodies in the same request. ::
-
-            [couchdb]
-            max_document_size = 4294967296 ; 4 GB
-
     .. config:option:: os_process_timeout :: External processes time limit
 
         If an external process, such as a query server or external process,

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -221,6 +221,28 @@ HTTP Server Options
             [httpd]
             WWW-Authenticate = Basic realm="Welcome to the Couch!"
 
+    .. config:option:: max_http_request_size :: Maximum HTTP request body size
+
+        .. versionchanged:: 2.1.0
+
+        Limit the maximum size of the HTTP request body. This setting applies
+        to all requests and it doesn't discriminate between single vs.
+        multi-document operations. So setting it to 1MB would block a
+        `PUT` of a document larger than 1MB, but it might also block a
+        `_bulk_docs` update of 1000 1KB documents, or a multipart/related
+        update of a small document followed by two 512KB attachments. This
+        setting is intended to be used as a protection aginst maliciously
+        large HTTP requests rather than for limiting maximum document sizes. ::
+
+            [httpd]
+            max_http_request_size = 4294967296 ; 4 GB
+
+        .. warning::
+           Before version 2.1.0 couchdb.max_document_size was implemented
+           effectively as max_http_request_size. That is, it checkeded HTTP
+           request bodies instead of document sizes. After the upgrade, it is
+           advisable to review the usage of these configuration settings.
+
 .. _config/ssl:
 
 Secure Socket Level Options


### PR DESCRIPTION
COUCHDB-2992