### PR TITLE
Remove pdf and info builds from default target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,6 @@ python:
   - 2.7
   - 3.4
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -yqq texlive-latex-base
-  - sudo apt-get install -yqq texlive-latex-extra
-  - sudo apt-get install -yqq texlive-latex-recommended
-  - sudo apt-get install -yqq texlive-fonts-recommended
-  - sudo apt-get install -yqq texinfo
-
 install:
   - pip install sphinx
 
@@ -20,7 +12,7 @@ script:
 env:
   matrix:
     - TARGET=html
-    - TARGET=pdf
+    - TARGET=man
     - TARGET=check
 
 cache: apt

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SPHINXOPTS   := $(SPHINXFLAGS) $(SOURCE)
 
 ENSURECMD=which $(1) > /dev/null 2>&1 || (echo "*** Make sure that $(1) is installed and on your path" && exit 1)
 
-all: html pdf info man
+all: html man
 
 clean:
 	rm -rf $(BUILDDIR)


### PR DESCRIPTION
As discussed on the mailing list, this removes the PDF and info
builds from the default build.

Fixes COUCHDB-3329

Relates to apache/couchdb:3329-kill-pdf-texinfo branch.