### PR TITLE
Update all references to instance_start_time

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -107,7 +107,7 @@
             "disk_size": 137433211,
             "doc_count": 6146,
             "doc_del_count": 64637,
-            "instance_start_time": "1376269325408900",
+            "instance_start_time": "0",
             "purge_seq": 0,
             "update_seq": 292786
         }

--- a/src/api/database/compact.rst
+++ b/src/api/database/compact.rst
@@ -162,8 +162,8 @@
     :<header Content-Type: :mimetype:`application/json`
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
-    :>json string instance_start_time: Timestamp of when the database
-        was opened, expressed in microseconds since the epoch.
+    :>json string instance_start_time: Always ``"0"``. (Returned for legacy
+      reasons.)
     :>json boolean ok: Operation status
     :code 201: Commit completed successfully
     :code 400: Invalid database name
@@ -190,7 +190,7 @@
         Server: CouchDB (Erlang/OTP)
 
         {
-            "instance_start_time": "1376269047459338",
+            "instance_start_time": "0",
             "ok": true
         }
 

--- a/src/intro/curl.rst
+++ b/src/intro/curl.rst
@@ -75,7 +75,7 @@ the return information formatted for clarity):
         "doc_del_count" : 0,
         "disk_format_version" : 5,
         "update_seq" : 0,
-        "instance_start_time" : "1306421773496000",
+        "instance_start_time" : "0",
         "disk_size" : 79
     }
 

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -545,7 +545,7 @@ write normal documents::
 .. code-block:: javascript
 
     {"db_name":"mydatabase","doc_count":1,"doc_del_count":0,"update_seq":3,"purge_seq":0,
-    "compact_running":false,"disk_size":12376,"data_size":272,"instance_start_time":"1397672867731570",
+    "compact_running":false,"disk_size":12376,"data_size":272,"instance_start_time":"0",
     "disk_format_version":6,"committed_update_seq":3}
 
 If Jan attempted to create a design doc, however, CouchDB would return a

--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -103,7 +103,7 @@ information about it via :ref:`database information resource <api/db>`::
         "disk_size": 17703025,
         "doc_count": 5091,
         "doc_del_count": 0,
-        "instance_start_time": "1371660751878859",
+        "instance_start_time": "0",
         "purge_seq": 0,
         "update_seq": 76215
     }

--- a/src/replication/protocol.rst
+++ b/src/replication/protocol.rst
@@ -362,8 +362,8 @@ The Replicator retrieves basic information both from Source and Target using
 :get:`/{db}` requests. The GET response MUST contain JSON objects with
 the following mandatory fields:
 
-- **instance_start_time** (*string*): Timestamp when the Database was
-  opened, expressed in *microseconds* since the epoch.
+- **instance_start_time** (*string*): Always ``"0"``. (Returned for legacy
+  reasons.)
 - **update_seq** (*number* / *string*): The current database Sequence ID.
 
 Any other fields are optional. The information that the Replicator needs
@@ -403,7 +403,7 @@ Get Source Information
             "disk_size": 79132913799,
             "doc_count": 41961,
             "doc_del_count": 3807,
-            "instance_start_time": "1380901070238216",
+            "instance_start_time": "0",
             "purge_seq": 0,
             "update_seq": 61772
         }
@@ -1566,7 +1566,7 @@ following mandatory fields:
       Server: CouchDB (Erlang/OTP)
 
       {
-          "instance_start_time": "1381218659871282",
+          "instance_start_time": "0",
           "ok": true
       }
 

--- a/src/whatsnew/2.0.rst
+++ b/src/whatsnew/2.0.rst
@@ -69,6 +69,7 @@ Version 2.0.0
   Windows
 * :ref:`Configuration <api/config>` has moved from ``/_config`` to
   ``/_node/{node-name}/_config``
+* ``instance_start_time`` now always reports ``"0"``.
 
 .. _release/2.0.x/upgrade:
 


### PR DESCRIPTION
Previously, the new behavior (that instance_start_time is always "0") was
mentioned only in one place. This updates it throughout the documentation.