### PR TITLE
Update documentation to point to GitHub issues for new issues

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -110,6 +110,7 @@ texinfo_documents = [(
 
 extlinks = {
     'issue': ('%s-%%s' % 'https://issues.apache.org/jira/browse/COUCHDB', 'COUCHDB-'),
+    'ghissue': ('https://github.com/apache/couchdb/issues/%s', '#'),
     'commit': ('https://git-wip-us.apache.org/repos/asf?p=couchdb.git;a=commit;h=%s', '#')
 }
 

--- a/src/cve/index.rst
+++ b/src/cve/index.rst
@@ -66,7 +66,7 @@ repeatedly). In general our philosophy is to avoid any attacks which can
 cause the server to consume resources in a non-linear relationship to the
 size of inputs.
 
-.. _bug reporting page: https://issues.apache.org/jira/browse/COUCHDB
+.. _bug reporting page: https://github.com/apache/couchdb/issues
 .. _mailing lists page: http://couchdb.apache.org/#mailing-list
 .. _how the Apache Software Foundation handles security: http://apache.org/security/committers.html
 .. _security@couchdb.apache.org: mailto:security@couchdb.apache.org

--- a/src/fauxton/install.rst
+++ b/src/fauxton/install.rst
@@ -77,6 +77,7 @@ layout, data, breadcrumbs and api point is required for the view.
 ToDo items
 ----------
 
-Checkout `JIRA`_  for a list of items to do.
+Checkout `JIRA` or `GitHub Issues`_  for a list of items to do.
 
 .. _JIRA: https://issues.apache.org/jira/browse/COUCHDB/component/12320406
+.. _GitHub Issues: https://github.com/apache/couchdb-fauxton/issues

--- a/src/whatsnew/2.0.rst
+++ b/src/whatsnew/2.0.rst
@@ -97,7 +97,7 @@ Known Issues
 ============
 
 All `known issues`_ filed against the 2.0 release are contained within the
-official `CouchDB JIRA instance`.
+official `CouchDB JIRA instance` or `CouchDB GitHub Issues`.
 
 The following are some highlights of known issues for which fixes did not land
 in time for the 2.0.0 release:
@@ -130,3 +130,4 @@ in time for the 2.0.0 release:
 
 .. _known issues: https://s.apache.org/couchdb-2.0-known-issues
 .. _CouchDB JIRA instance: https://issues.apache.org/jira/browse/COUCHDB
+.. _CouchDB GitHub Issues: https://github.com/apache/couchdb/issues

--- a/src/whatsnew/2.1.rst
+++ b/src/whatsnew/2.1.rst
@@ -101,5 +101,3 @@ Upgrade Notes
   with transient replication states. However, that will incure a
   performance cost. Consider instead switching using
   ``_scheduler/docs`` HTTP endpoint.
-
-.. _CouchDB JIRA instance: https://issues.apache.org/jira/browse/COUCHDB

--- a/templates/help.html
+++ b/templates/help.html
@@ -20,7 +20,7 @@ specific language governing permissions and limitations under the License.
 <li><a href="https://cwiki.apache.org/confluence/display/COUCHDB/">Wiki</a></li>
 <li><a href="https://couchdb.apache.org/#mailing-list"{% if not local %} onclick="_gaq.push(['_link', 'https://couchdb.apache.org/#mailing-list']); return false;"{% endif %}>Mailing Lists</a></li>
 <li><a href="http://webchat.freenode.net/?channels=couchdb">IRC</a></li>
-<li><a href="https://issues.apache.org/jira/browse/CouchDB">Issues</a></li>
+<li><a href="https://github.com/apache/couchdb/issues">Issues</a></li>
 <li><a href="{{ pathto('download') }}">Download Docs</a></li>
 {%- if github_show_url %}
 <li><a href="{{ github_show_url }}"


### PR DESCRIPTION
This PR updates our actual documentation (as opposed to contributing/issue/pr files) with pointers to the new GitHub Issues link rather than JIRA. It includes a macro `ghissue` similar to the original `issue` for quick-linking to new issues.

`make check` passes.