### PR TITLE
POST /dbname should not return ETag response header

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -292,7 +292,6 @@
       <api/doc/batch-writes>` Possible values: ``ok``. *Optional*
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
-    :>header ETag: Quoted new document's revision
     :>header Location: Document's URI
     :>json string id: Document ID
     :>json boolean ok: Operation status
@@ -328,7 +327,6 @@
         Content-Length: 95
         Content-Type: application/json
         Date: Tue, 13 Aug 2013 15:19:25 GMT
-        ETag: "1-9c65296036141e575d32ba9c034dd3ee"
         Location: http://localhost:5984/db/ab39fe0993049b84cfa81acd6ebad09d
         Server: CouchDB (Erlang/OTP)
 

--- a/src/whatsnew/2.0.rst
+++ b/src/whatsnew/2.0.rst
@@ -135,3 +135,15 @@ in time for the 2.0.0 release:
 .. _known issues: https://s.apache.org/couchdb-2.0-known-issues
 .. _CouchDB JIRA instance: https://issues.apache.org/jira/browse/COUCHDB
 .. _CouchDB GitHub Issues: https://github.com/apache/couchdb/issues
+
+.. _release/2.0.x/breakingchanges:
+
+Breaking Changes
+================
+
+The following changes in 2.0 represent a significant deviation from
+CouchDB 1.x and may alter behaviour of systems designed to work with
+older versions of CouchDB:
+
+* :ghissue:`620`: ``POST /dbname`` no longer returns an ETag reponse header,
+  in compliance with RFC 7231, Section 7.2.


### PR DESCRIPTION
as it relates to a different resource.

Note: We used to send ETag for this in previous releases, so it's
technically a regression even though we accidentally fix a spec
violation.

Closes apache/couchdb#620
