### PR TITLE
Advertise convenience binaries for installation

### DIFF
--- a/src/install/docker.rst
+++ b/src/install/docker.rst
@@ -1,0 +1,41 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. _install/docker:
+
+=======================
+Installation via Docker
+=======================
+
+Apache CouchDB provides 'convenience binary' Docker images through
+Docker Hub at ``apache/couchdb``. The following tags are available:
+
+* ``latest``, ``2.1.0``: CouchDB 2.1, single node
+* ``1``, ``1.6``, ``1.6.1``: CouchDB 1.6.1
+* ``1-couchperuser``, ``1.6-couchperuser``, ``1.6.1-couchperuser``: CouchDB
+  1.6.1 with couchperuser plugin
+* ``2.0.0``: CouchDB 2.0, single node
+
+These images are built using Debian 8 (jessie), expose CouchDB on port
+``5984`` of the container, run everything as user ``couchdb``, and support
+use of a Docker volume for data at ``/opt/couchdb/data``.
+
+Note that you can also use the ``NODENAME`` environment variable to set the
+name of the CouchDB node inside the container.
+
+**Be sure to complete the** :ref:`First-time Setup <install/setup>` **steps for
+a single node or clustered installation.**
+
+Further details on the Docker configuration are available in our
+`couchdb-docker git repository`_.
+
+.. _couchdb-docker git repository: https://github.com/apache/couchdb-docker

--- a/src/install/index.rst
+++ b/src/install/index.rst
@@ -23,6 +23,8 @@ Installation & First-Time Setup
     windows
     mac
     freebsd
+    docker
+    snap
     setup
     upgrading
     troubleshooting

--- a/src/install/mac.rst
+++ b/src/install/mac.rst
@@ -12,24 +12,24 @@
 
 .. _install/mac:
 
-========================
-Installation on Mac OS X
-========================
+=====================
+Installation on macOS
+=====================
 
 .. _install/mac/binary:
 
 Installation using the Apache CouchDB native application
 ========================================================
 
-The easiest way to run CouchDB on Mac OS X is through the native Mac OS X
+The easiest way to run CouchDB on macOS is through the native macOS
 application. Just follow the below instructions:
 
-#. `Download Apache CouchDB for Mac OS X`_.
+#. `Download Apache CouchDB for macOS`_.
    Old releases are available at `archive`_.
 #. Double click on the Zip file
 #. Drag and drop the Apache CouchDB.app into Applications folder
 
-.. _Download Apache CouchDB for Mac OS X: http://couchdb.org/#download
+.. _Download Apache CouchDB for macOS: http://couchdb.org/#download
 .. _archive: http://archive.apache.org/dist/couchdb/binary/mac/
 
 That's all, now CouchDB is installed on your Mac:
@@ -48,24 +48,30 @@ That's all, now CouchDB is installed on your Mac:
 Installation with Homebrew
 ==========================
 
-The `Homebrew`_ build of CouchDB 2.0 is still in development. Check back often
+The `Homebrew`_ build of CouchDB 2.x is still in development. Check back often
 for updates.
 
 .. _Homebrew: http://brew.sh/
 
+Installation from source
+========================
+
+Installation on macOS is possible from source. Download the `source tarball`_,
+extract it, and follow the instructions in the ``INSTALL.Unix.md`` file.
+
+.. _source tarball: http://couchdb.org/#download
+
 Running as a Daemon
 -------------------
 
-CouchDB no longer ships with any daemonization scripts.
-
-You can use the `launchctl` command to control the CouchDB daemon.
+CouchDB itself no longer ships with any daemonization scripts.
 
 The couchdb team recommends `runit <http://smarden.org/runit/>`_ to
 run CouchDB persistently and reliably. Configuration of runit is
 straightforward; if you have questions, reach out to the CouchDB
 user mailing list.
 
-Naturally, you can configure launchd or other init daemons to
-launch CouchDB and keep it running using standard configuration files.
+Naturally, you can configure launchd or other init daemons to launch CouchDB
+and keep it running using standard configuration files.
 
 Consult your system documentation for more information.

--- a/src/install/setup.rst
+++ b/src/install/setup.rst
@@ -31,14 +31,14 @@ single-node setup obviously doesn't take any advantage of the new
 scaling and fault-tolerance features in CouchDB 2.0.
 
 After installation and initial startup, visit Fauxton at
-``http://127.0.0.01:5984/_utils#setup``. You will be asked to set up
+``http://127.0.0.1:5984/_utils#setup``. You will be asked to set up
 CouchDB as a single-node instance or set up a cluster. When you click
 “Single-Node-Setup”, you will get asked for an admin username and
 password. Choose them well and remember them. You can also bind CouchDB
 to a public port, so it is accessible within your LAN or the public, if
 you are doing this on a public VM. The wizard then configures your admin
-username and password and creates the three system databases _users,
-_replicator and _global_changes for you.
+username and password and creates the three system databases ``_users``,
+``_replicator`` and ``_global_changes`` for you.
 
 Alternatively, if you don't want to use the “Single-Node-Setup” wizard
 and run 2.0 as a single node with admin username and password already

--- a/src/install/snap.rst
+++ b/src/install/snap.rst
@@ -1,0 +1,38 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. _install/snap:
+
+=====================
+Installation via Snap
+=====================
+
+.. highlight:: sh
+
+Apache CouchDB provides 'convenience binary' Snap builds through the
+Ubuntu snapcraft repository under the name ``couchdb``. Only snaps built
+from official stable CouchDB releases (``2.0``, ``2.1``, etc.) are available
+through this channel.
+
+After `installing snapd`_, the couchdb snap can be installed via::
+
+    $ sudo snap install couchdb
+
+CouchDB will be installed at ``/snap/couchdb``. Data will be stored at
+``/var/snap/couchdb/``.
+
+.. _installing snapd: https://snapcraft.io/docs/core/install
+
+Further details on the snap build process are available in our
+`couchdb-pkg git repository`_.
+
+.. _couchdb-pkg git repository: https://github.com/apache/couchdb-pkg

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -16,9 +16,88 @@
 Installation on Unix-like systems
 =================================
 
-A high-level guide to Unix-like systems, including Mac OS X and Ubuntu.
+.. _install/unix/binary:
 
-This document as well as the INSTALL.Unix document in the official
+Installation using the Apache CouchDB convenience binary packages
+=================================================================
+
+If you are running one of the following operating systems, the easiest way
+to install CouchDB is to use the convenience binary packages:
+
+* CentOS/RHEL 6
+* CentOS/RHEL 7
+* Debian 8 (jessie)
+* Ubuntu 14.04 (trusty)
+* Ubuntu 16.04 (xenial)
+
+The RedHat-style rpm packages and Debian-style deb pacakges will install
+CouchDB at ``/opt/couchdb`` and ensure CouchDB is run at system startup by the
+appropriate init subsystem (SysV-style initd, upstart, systemd).
+
+The Debian-style deb packages *also* pre-configure CouchDB as a standalone or
+clustered node, prompt for the address to which it will bind, and a password
+for the admin user. Responses to these prompts may be pre-seeded using standard
+debconf tools. Further details are in the `README.Debian`_ file.
+
+.. _README.Debian: https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
+
+Enabling the Apache CouchDB package repository
+----------------------------------------------
+
+.. highlight:: ini
+
+**RedHat/CentOS**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
+
+    [bintray--apache-couchdb-rpm]
+    name=bintray--apache-couchdb-rpm
+    baseurl=http://apache.bintray.com/couchdb-rpm/el$releasever/$basearch/
+    gpgcheck=0
+    repo_gpgcheck=0
+    enabled=1
+
+.. highlight:: sh
+
+**Debian/Ubuntu**: Run the command::
+
+    $ echo "deb https://apache.bintray.com/couchdb-deb {distribution} main" \
+    | sudo tee -a /etc/apt/sources.list
+
+and replace ``{distribution}`` with the appropriate choice for your OS
+version:
+
+* Debian 8: ``jessie``
+* Ubuntu 14.04: ``trusty``
+* Ubuntu 16.04: ``xenial``
+
+Installing the Apache CouchDB packages
+--------------------------------------
+
+**RedHat/CentOS**: Run the command::
+
+    $ sudo yum -y install epel-release && yum install couchdb
+
+**Be sure to complete the** :ref:`First-time Setup <install/setup>` **steps for
+a single node or clustered installation.**
+
+**Debian/Ubuntu**: Run the command::
+
+    $ sudo apt-get update && sudo apt-get install couchdb
+
+Debian/Ubuntu installs from binaries will be pre-configured for single node or
+clustered installations. For clusters, multiple nodes will still need to be
+joined together; **follow the**
+:ref:`Cluster Setup Wizard <cluster/setup/wizard>` **steps** to complete the
+process.
+
+Relax! CouchDB is installed and running.
+
+Installation from source
+========================
+
+The remainder of this document describes the steps required to install CouchDB
+directly from source code.
+
+This guide, as well as the INSTALL.Unix document in the official tarball
 release are the canonical sources of installation information. However, many
 systems have gotchas that you need to be aware of. In addition, dependencies
 frequently change as distributions update their archives.

--- a/src/install/windows.rst
+++ b/src/install/windows.rst
@@ -23,22 +23,13 @@ Installation from binaries
 
 This is the simplest way to go.
 
-#. Get `the latest Windows binaries`_ from `CouchDB web site`_.
+#. Get `the latest Windows binaries`_ from the `CouchDB web site`_.
    Old releases are available at `archive`_.
 
-#. Follow the installation wizard steps:
+#. Follow the installation wizard steps. **Be sure to install CouchDB to a
+   path with no spaces, such as** ``C:\CouchDB``.
 
-   - Next on "Welcome" screen
-   - Accept the License agreement
-   - Select the installation directory
-   - Specify "Start Menu" group name
-   - Approve that you'd like to install CouchDB as service and let it be
-     started automatically after installation (probably, you'd like so)
-   - Verify installation settings
-   - Install CouchDB
-
-#. `Open up Fauxton`_ (if you hadn't selected autostart CouchDB after
-   installation, you have to start it first manually)
+#. `Open up Fauxton`_
 
 #. It's time to Relax! **Be sure to complete the** :ref:`First-time Setup
    <install/setup>` **steps for a single node or clustered installation.**
@@ -70,4 +61,4 @@ Installation from sources
 
 .. seealso::
     `Glazier: Automate building of CouchDB from source on Windows
-    <https://git1-us-west.apache.org/repos/asf?p=couchdb-glazier.git;a=tree>`_
+    <https://github.com/apache/couchdb-glazier>`_


### PR DESCRIPTION
This PR:

* updates the Mac and Windows installation instructions
* advertises the .deb/.rpm packages for Unix
* includes separate pointers for the Docker and snapstore convenience binaries
* corrects a few minor misspellings.

Closes #141.