### PR TITLE
Updated documentation for new replicator retries_per_request value

### DIFF
--- a/src/config/replicator.rst
+++ b/src/config/replicator.rst
@@ -103,10 +103,17 @@ Replicator Database Configuration
 
     .. config:option:: retries_per_request
 
-        If a request fails, the replicator will retry it up to N times::
+        .. versionchanged:: 2.1.1
+
+        If a request fails, the replicator will retry it up to N times. The
+        default value for N is 5 (before version 2.1.1 it was 10). The requests
+        are retried with an doubling exponenital backoff starting at 0.25
+        seconds. So by default requests would be retried in 0.25, 0.5, 1, 2, 4
+        second intervals. When number of retires is exhausted, the whole
+        replication job is stopped and will retry again later::
 
             [replicator]
-            retries_per_request = 10
+            retries_per_request = 5
 
     .. config:option:: socket_options
 


### PR DESCRIPTION
The new value is 5 but used to be 10, which makes more sense with the new
scheduling replicator behavior.

Issue #810

This is associated with this PR:

https://github.com/apache/couchdb/pull/843