### PR TITLE
httpd->chttpd for 2.x proxy auth and SSL

### DIFF
--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -275,11 +275,11 @@ Proxy Authentication
 .. note::
     To use this authentication method make sure that the
     ``{couch_httpd_auth, proxy_authentication_handler}`` value in added to the
-    list of the active :config:option:`httpd/authentication_handlers`:
+    list of the active :config:option:`chttpd/authentication_handlers`:
 
     .. code-block:: ini
 
-        [httpd]
+        [chttpd]
         authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
 
 `Proxy authentication` is very useful in case your application already uses

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -34,21 +34,6 @@ HTTP Server Options
 
         .. _JSONP: http://www.json-p.org/
 
-    .. config:option:: authentication_handlers :: Authentication handlers
-
-        List of used authentication handlers that used by CouchDB. You may
-        extend them via third-party plugins or remove some of them if you won't
-        let users to use one of provided methods::
-
-            [httpd]
-            authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
-
-        - ``{couch_httpd_auth, cookie_authentication_handler}``: used for Cookie auth;
-        - ``{couch_httpd_auth, proxy_authentication_handler}``: used for Proxy auth;
-        - ``{couch_httpd_auth, default_authentication_handler}``: used for Basic auth;
-        - ``{couch_httpd_auth, null_authentication_handler}``: disables auth.
-          Everlasting `Admin Party`!
-
     .. config:option:: bind_address :: Listen IP address
 
         Defines the IP address by which CouchDB will be accessible::
@@ -241,7 +226,7 @@ HTTP Server Options
            request bodies instead of document sizes. After the upgrade, it is
            advisable to review the usage of these configuration settings.
 
-.. config:section:: chttpd :: HTTP Server Options
+.. config:section:: chttpd :: Clustered HTTP Server Options
 
     .. config:option:: prefer_minimal :: Sends minimal set of headers
 
@@ -256,6 +241,21 @@ HTTP Server Options
             Removing the Server header from the settings will mean that
             the CouchDB server header is replaced with the
             Mochiweb server header.
+
+    .. config:option:: authentication_handlers :: Authentication handlers
+
+        List of authentication handlers used by CouchDB. You may
+        extend them via third-party plugins or remove some of them if you won't
+        let users to use one of provided methods::
+
+            [chttpd]
+            authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+
+        - ``{couch_httpd_auth, cookie_authentication_handler}``: used for Cookie auth;
+        - ``{couch_httpd_auth, proxy_authentication_handler}``: used for Proxy auth;
+        - ``{couch_httpd_auth, default_authentication_handler}``: used for Basic auth;
+        - ``{couch_httpd_auth, null_authentication_handler}``: disables auth.
+          Everlasting `Admin Party`!
 
 .. _config/ssl:
 
@@ -295,7 +295,7 @@ Secure Socket Level Options
     At first, :option:`enable the HTTPS daemon <daemons/httpsd>`::
 
         [daemons]
-        httpsd = {couch_httpd, start_link, [https]}
+        httpsd = {chttpd, start_link, [https]}
 
     Next, under the ``[ssl]`` section set up the newly generated certificates::
 

--- a/src/config/services.rst
+++ b/src/config/services.rst
@@ -48,7 +48,7 @@ CouchDB Daemonized Mini Apps
 
     .. config:option:: httpd
 
-        HTTP server daemon::
+        Node-local HTTP server daemon (default port: `5986`)::
 
             [daemons]
             httpd={couch_httpd, start_link, []}
@@ -59,7 +59,7 @@ CouchDB Daemonized Mini Apps
         listens on is `6984`::
 
             [daemons]
-            httpsd = {couch_httpd, start_link, [https]}
+            httpsd = {chttpd, start_link, [https]}
 
     .. config:option:: index_server
 

--- a/src/whatsnew/1.6.rst
+++ b/src/whatsnew/1.6.rst
@@ -29,7 +29,7 @@ The :ref:`Proxy Authentication <api/auth/proxy>` handler was renamed to
 ``proxy_authentication_handler`` to follow the ``*_authentication_handler`` form
 of all other handlers. The old ``proxy_authentification_handler`` name is marked
 as deprecated and will be removed in future releases. It's strongly recommended
-to update :config:option:`httpd/authentication_handlers` option with new value
+to update ``httpd/authentication_handlers`` option with new value
 in case if you had used such handler.
 
 .. _release/1.6.0:


### PR DESCRIPTION
We fixed this in https://issues.apache.org/jira/browse/COUCHDB-3203 but never updated the docs to match.