### PR TITLE
compacter is enabled by default.

### DIFF
--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -184,6 +184,6 @@ triggered based on various criteria. Automatic compaction is configured in
 CouchDB's :ref:`configuration files <config/intro>`.
 
 The :config:option:`daemons/compaction_daemon` is responsible for triggering
-the compaction. It is automatically started, but disabled by default.
+the compaction. It is enabled by default and automatically started.
 The criteria for triggering the compactions is configured in the
 :config:section:`compactions` section.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The current documentation suggests the compacter is disabled by default, as by having its options commented out in .ini files. As of 2.1+ the compacter is enabled by default, per @wohali :

> [freenode#couchdb] Wohali: compaction is now enabled by default in 2.1.0 and up

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

Fixes #170

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
