### PR TITLE
Clarify usage of COPY

### DIFF
--- a/src/api/ddoc/common.rst
+++ b/src/api/ddoc/common.rst
@@ -81,7 +81,7 @@
     :synopsis: Copies the design document
 
     The :method:`COPY` (which is non-standard HTTP) copies an existing design
-    document to a new or existing one.
+    document to a new one.
 
     Given that view indexes on disk are named after their MD5 hash of the
     view definition, and that a `COPY` operation won't actually change

--- a/src/api/document/common.rst
+++ b/src/api/document/common.rst
@@ -335,7 +335,7 @@
     :synopsis: Copies the document within the same database
 
     The :method:`COPY` (which is non-standard HTTP) copies an existing
-    document to a new or existing document.
+    document to a new document.
 
     The source document is specified on the request line, with the
     :header:`Destination` header of the request specifying the target


### PR DESCRIPTION
The documentation suggests that COPY can be used to overwrite the target document, but there's no (obvious) way to actually do this.  The `rev` parameter is used for the source, and there is no (documented/obvious) way to specify the rev for the target document to update. This leads me to believe it is mis-documented.

If someone can explain that my assumption is incorrect, I'll instead update the docs to explain how to overwrite the target.