### PR TITLE
Remove mention of Content-MD5 header, which isn't present

### DIFF
--- a/src/api/document/attachments.rst
+++ b/src/api/document/attachments.rst
@@ -41,7 +41,6 @@
       types <attachments/compressible_types>`
     :>header Content-Length: Attachment size. If compression codec was used,
       this value is about compressed size, not actual
-    :>header Content-MD5: Base64 encoded MD5 binary digest
     :>header ETag: Double quoted base64 encoded MD5 binary digest
     :code 200: Attachment exists
     :code 304: Attachment wasn't modified if :header:`ETag` equals specified
@@ -65,7 +64,6 @@
         Cache-Control: must-revalidate
         Content-Encoding: gzip
         Content-Length: 100
-        Content-MD5: vVa/YgiE1+Gh0WfoFJAcSg==
         Content-Type: text/plain
         Date: Thu, 15 Aug 2013 12:42:42 GMT
         ETag: "vVa/YgiE1+Gh0WfoFJAcSg=="
@@ -96,7 +94,6 @@
       types <attachments/compressible_types>`
     :>header Content-Length: Attachment size. If compression codec is used,
       this value is about compressed size, not actual
-    :>header Content-MD5: Base64 encoded MD5 binary digest
     :>header ETag: Double quoted base64 encoded MD5 binary digest
     :response: Stored content
     :code 200: Attachment exists


### PR DESCRIPTION
My tests with 1.6.1, 2.0.0 and 2.1.0 all suggest that the `Content-MD5` header is not set in GET or HEAD responses when querying attachments.  Perhaps this was removed after the `ETag` header was added, as they are practically duplicates?

Example, from 2.1.0:

```
$ curl -v -X GET http://admin:abc123@localhost:6002/foo/foo/foo.txt
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 6002 (#0)
* Server auth using Basic with user 'admin'
> GET /foo/foo/foo.txt HTTP/1.1
> Host: localhost:6002
> Authorization: Basic YWRtaW46YWJjMTIz
> User-Agent: curl/7.52.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: CouchDB/2.1.0 (Erlang OTP/17)
< ETag: "ENGoH7oK8V9R3BMnfDHZmw=="
< Date: Thu, 26 Oct 2017 21:31:41 GMT
< Content-Type: text/plain
< Content-Length: 13
< Cache-Control: must-revalidate
< Accept-Ranges: none
< 
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
Hello, World!
```