### PR TITLE
Update the PUT {attachment} docs to reflect observed behavior.

### DIFF
--- a/src/api/document/attachments.rst
+++ b/src/api/document/attachments.rst
@@ -109,10 +109,11 @@
     :synopsis: Adds an attachment of a document
 
     Uploads the supplied content as an attachment to the specified document.
-    The attachment name provided must be a URL encoded string. You must also
-    supply either the ``rev`` query argument or the :header:`If-Match` HTTP
-    header for validation, and the HTTP headers (to set the attachment content
-    type).
+    The attachment name provided must be a URL encoded string. You must supply
+    the Content-Type header, and for an existing document you must also supply
+    either the ``rev`` query argument or the :header:`If-Match` HTTP header. If
+    the revision is omitted, a new, otherwise empty document will be created
+    with the provided attachment, or a conflict will occur.
 
     If case when uploading an attachment using an existing attachment name,
     CouchDB will update the corresponding stored content of the database. Since
@@ -129,7 +130,7 @@
     :param attname: Attachment name
     :<header Content-Type: Attachment MIME type. *Required*
     :<header If-Match: Document revision. Alternative to `rev` query parameter
-    :query string rev: Document revision. *Required*
+    :query string rev: Document revision. *Optional*
     :>json string id: Document ID
     :>json boolean ok: Operation status
     :>json string rev: Revision MVCC token


### PR DESCRIPTION
This updates the docs to reflect that it is possible to create an empty document with `PUT /{db}/{docid}/{attname}`.  Example with 2.1.0:

```
$ curl -v -X PUT http://admin:abc123@localhost:6002/foo/asdf/asdf.txt -H 'Content-Type: text/plain' -d 'Foo'
*   Trying ::1...                                                                                                                                                                                                                
* TCP_NODELAY set                                                                                                                                                                                                                
* Connected to localhost (::1) port 6002 (#0)                                                                                                                                                                                    
* Server auth using Basic with user 'admin'                                                                                                                                                                                      
> PUT /foo/asdf/asdf.txt HTTP/1.1                                                                                                                                                                                                
> Host: localhost:6002                                                                                                                                                                                                           
> Authorization: Basic YWRtaW46YWJjMTIz                                                                                                                                                                                          
> User-Agent: curl/7.52.1                                                                                                                                                                                                        
> Accept: */*                                                                                                                                                                                                                    
> Content-Type: text/plain                                                                                                                                                                                                       
> Content-Length: 3                                                                                                                                                                                                              
>                                                                                                                                                                                                                                
* upload completely sent off: 3 out of 3 bytes                                                                                                                                                                                   
< HTTP/1.1 201 Created                                                                                                                                                                                                           
< X-CouchDB-Body-Time: 0                                                                                                                                                                                                         
< X-Couch-Request-ID: 10e7ef8da3                                                                                                                                                                                                 
< Server: CouchDB/2.1.0 (Erlang OTP/17)
< Location: http://localhost:6002/foo/asdf/asdf.txt
< Date: Thu, 26 Oct 2017 21:59:14 GMT
< Content-Type: application/json
< Content-Length: 67
< Cache-Control: must-revalidate
< 
{"ok":true,"id":"asdf","rev":"1-50e6c151017d2056dde49c7a02388b29"}
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
```