### PR TITLE
Modify articles, commas, and spelling in the 'DELETE operation' section for clarity.

### DIFF
--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -223,8 +223,8 @@ revision which contains the ``_id`` and ``_rev`` fields as well as
 the `_deleted` flag. This revision will remain even after a `database
 compaction` so that the deletion can be replicated. Deleted documents, like
 non-deleted documents, can affect view build times, :method:`PUT` and
-:method:`DELETE` requests time and size of database on disk, since they
-increase the size of the B+Tree's. You can see the number of deleted documents
+:method:`DELETE` request times, and the size of the database since they
+increase the size of the B+Tree. You can see the number of deleted documents
 in :get:`database information </{db}>`. If your use case creates lots of
 deleted documents (for example, if you are storing short-term data like log
 entries, message queues, etc), you might want to periodically switch to a new


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The "DELETE operation" section of maintenance/performance.rst is unclear. This PR replaces "B+Tree's" with "B+Tree" and otherwise adds a few instances of "the" for clarity.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
