### PR TITLE
Clarify change to default node name in 2.1.1

### DIFF
--- a/src/whatsnew/2.1.rst
+++ b/src/whatsnew/2.1.rst
@@ -25,6 +25,15 @@
 Upgrade Notes
 =============
 
+* When upgrading from 2.x to 2.1.1, if you have not customized your
+  node name in ``vm.args``, be sure to retain your original ``vm.args``
+  file. The default node name has changed from ``couchdb@localhost`` to
+  ``couchdb@127.0.0.1``, which can prevent CouchDB from accessing existing
+  databases on the system. You may also change the name option back to the
+  old value by setting ``-name couchdb@localhost`` in ``etc/vm.args`` by
+  hand. The default has changed to meet new guidelines and to provide
+  additional functionality in the future.
+
 * The deprecated (and broken) OAuth 1.0 implementation has been removed.
 
 * If user code reads or manipulates replicator document states,


### PR DESCRIPTION
user@ reported that the change to the default node name tripped them up. Would be wise to add the remediation steps to the release notes.