### PR TITLE
Fix _cluster_setup api | couchdb node name changes | verify cluster setup  

### DIFF
--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -167,6 +167,11 @@ Before you can add nodes to form a cluster, you have to have them
 listen on a public IP address and set up an admin user. Do this, once
 per node:
 
+.. note::
+change line ``-name couchdb@127.0.0.1`` in file /Couch-Install-Home/etc/vm.args
+on each node for clustered setup, each node in the system must have a unique name
+eg. ``-name couchdb@couch1`` and ``-name couchdb@couch2``
+
 .. code-block:: bash
 
     curl -X PUT http://127.0.0.1:5984/_node/couchdb@<this-nodes-ip-address>/_config/admins/admin -d '"password"'
@@ -211,12 +216,11 @@ requires all other nodes to be able to see it and vice versa.
 Set up will not work with unavailable nodes.
 The notion of "setup coordination node" will be gone once the setup is finished.
 From then on, the cluster will no longer have a "setup coordination node".
-To add a node run these two commands:
+To add a node run this commands for each node you want to add:
 
 .. code-block:: bash
 
-    curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "enable_cluster", "bind_address":"0.0.0.0", "username": "admin", "password":"password", "port": 15984, "node_count": "3", "remote_node": "<remote-node-ip>", "remote_current_user": "<remote-node-username>", "remote_current_password": "<remote-node-password>" }'
-    curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "add_node", "host":"<remote-node-ip>", "port": "<remote-node-port>", "username": "admin", "password":"password"}'
+    curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "add_node", "host":"<remote-node-ip>", "port": <remote-node-port>, "username": "admin", "password":"password"}'
 
 This will join the two nodes together.
 Keep running the above commands for each
@@ -226,6 +230,29 @@ following command to complete the setup and add the missing databases:
 .. code-block:: bash
 
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "finish_cluster"}'
+
+Verify install
+.. code-block:: bash
+    curl http://admin:password@127.0.0.1:5984/_cluster_setup
+Response
+.. code-block:: bash
+    {"state":"cluster_finished"}
+
+Verify cluster nodes
+.. code-block:: bash
+    curl http://admin:password@127.0.0.1:5984/_membership
+Response
+.. code-block:: bash
+    {
+    "all_nodes": [
+        "couchdb@couch1",
+        "couchdb@couch2",
+    ],
+    "cluster_nodes": [
+        "couchdb@couch1",
+        "couchdb@couch2",
+    ]
+}
 
 You CouchDB cluster is now set up.
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -167,9 +167,9 @@ Before you can add nodes to form a cluster, you have to have them
 listen on a public IP address and set up an admin user. Do this, once
 per node:
 
-Change line ``-name couchdb@127.0.0.1`` in file /Couch-Install-Home/etc/vm.args
-on each node for clustered setup, each node in the system must have a unique name.
-eg. ``-name couchdb@couch1`` and ``-name couchdb@couch2``
+Change line ``-name couchdb@127.0.0.1`` in file /Couch-Home/etc/vm.args on
+each node for clustered setup, each node in system must have a unique name.
+eg. ``-name couchdb@couch1`` | ``-name couchdb@couch2``
 
 .. code-block:: bash
 
@@ -232,7 +232,7 @@ following command to complete the setup and add the missing databases:
 
 Verify install:
 
-.. code-block::
+.. code-block:: bash
 
     curl http://admin:password@127.0.0.1:5984/_cluster_setup
 
@@ -241,7 +241,6 @@ Response:
 .. code-block:: bash
 
     {"state":"cluster_finished"}
-
 
 Verify cluster nodes:
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -163,15 +163,15 @@ then to add nodes by IP address. To get more nodes, go through the same install
 procedure on other machines. Be sure to specify the total number of nodes you
 expect to add to the cluster before adding nodes.
 
-Before you can add nodes to form a cluster, you have to have them
-listen on a node address if all nodes can communicate over those IP's,
-also set up an admin user which should be same on all nodes. Do this, once
-per node:
+Before you can add nodes to form a cluster, you must have them listening on an
+IP address accessible from the other nodes in the cluster. Do this once per node:
 
-In file etc/vm.args
-``-name couchdb@<this-nodes-ip-address| FQDN>`` which defines the node and must
-be seperate for each node. For clustered setup, each node in system must have a
-unique name .i.e. must be a valid FQDN not necessary IP.
+In file etc/vm.args  to -name couchdb@<this-nodes-ip-address> for each node. For clustered setup, each node in the system must have a unique name.
+
+In file etc/vm.args change the the line ``-name couchdb@127.0.0.1`` to 
+``-name couchdb@<this-nodes-ip-address| FQDN>`` for each node which defines 
+the node and must be seperate for each node. For clustered setup, each node in 
+system must have a unique name.Can also be a valid FQDN not necessarily the IP.
 
 .. code-block:: bash
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -168,7 +168,7 @@ listen on a node address if all nodes can communicate over those IP's,
 also set up an admin user which should be same on all nodes. Do this, once
 per node:
 
-In file etc/vm.args 
+In file etc/vm.args
 ``-name couchdb@<this-nodes-ip-address| FQDN>`` which defines the node and must
 be seperate for each node. For clustered setup, each node in system must have a
 unique name .i.e. must be a valid FQDN not necessary IP.

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -167,9 +167,8 @@ Before you can add nodes to form a cluster, you have to have them
 listen on a public IP address and set up an admin user. Do this, once
 per node:
 
-Change line ``-name couchdb@127.0.0.1`` in file /Couch-Home/etc/vm.args on
+Change line ``-name couchdb@127.0.0.1`` in file etc/vm.args on
 each node for clustered setup, each node in system must have a unique name.
-eg. ``-name couchdb@couch1`` | ``-name couchdb@couch2``
 
 .. code-block:: bash
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -167,9 +167,8 @@ Before you can add nodes to form a cluster, you have to have them
 listen on a public IP address and set up an admin user. Do this, once
 per node:
 
-.. note::
-change line ``-name couchdb@127.0.0.1`` in file /Couch-Install-Home/etc/vm.args
-on each node for clustered setup, each node in the system must have a unique name
+Change line ``-name couchdb@127.0.0.1`` in file /Couch-Install-Home/etc/vm.args
+on each node for clustered setup, each node in the system must have a unique name.
 eg. ``-name couchdb@couch1`` and ``-name couchdb@couch2``
 
 .. code-block:: bash
@@ -233,7 +232,7 @@ following command to complete the setup and add the missing databases:
 
 Verify install:
 
-.. code-block:: bash
+.. code-block::
 
     curl http://admin:password@127.0.0.1:5984/_cluster_setup
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -164,11 +164,13 @@ procedure on other machines. Be sure to specify the total number of nodes you
 expect to add to the cluster before adding nodes.
 
 Before you can add nodes to form a cluster, you have to have them
-listen on a public IP address and set up an admin user. Do this, once
+listen on a node address if all nodes can communicate over those IP's,
+also set up an admin user which should be same on all nodes. Do this, once
 per node:
-
-``-name couchdb@127.0.0.1`` in file etc/vm.args on
-For clustered setup, each node in system must have a unique name.
+In file etc/vm.args 
+``-name couchdb@<this-nodes-ip-address| FQDN>`` which defines the node and must
+be seperate for each node. For clustered setup, each node in system must have a
+unique name .i.e. must be a valid FQDN not necessary IP.
 
 .. code-block:: bash
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -214,10 +214,11 @@ requires all other nodes to be able to see it and vice versa.
 Set up will not work with unavailable nodes.
 The notion of "setup coordination node" will be gone once the setup is finished.
 From then on, the cluster will no longer have a "setup coordination node".
-To add a node run this commands for each node you want to add:
+To add a node run these commands for each node you want to add:
 
 .. code-block:: bash
-
+    curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "enable_cluster", "bind_address":"0.0.0.0", "username": "admin", "password":"password", "port": 15984, "node_count": "3", "remote_node": "<remote-node-ip>", "remote_current_user": "<remote-node-username>", "remote_current_password": "<remote-node-password>" }'
+    
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "add_node", "host":"<remote-node-ip>", "port": <remote-node-port>, "username": "admin", "password":"password"}'
 
 This will join the two nodes together.

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -217,6 +217,7 @@ From then on, the cluster will no longer have a "setup coordination node".
 To add a node run these commands for each node you want to add:
 
 .. code-block:: bash
+
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "enable_cluster", "bind_address":"0.0.0.0", "username": "admin", "password":"password", "port": 15984, "node_count": "3", "remote_node": "<remote-node-ip>", "remote_current_user": "<remote-node-username>", "remote_current_password": "<remote-node-password>" }'
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "add_node", "host":"<remote-node-ip>", "port": <remote-node-port>, "username": "admin", "password":"password"}'
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -163,17 +163,14 @@ then to add nodes by IP address. To get more nodes, go through the same install
 procedure on other machines. Be sure to specify the total number of nodes you
 expect to add to the cluster before adding nodes.
 
-Before you can add nodes to form a cluster, you must have them listening on an
-IP address accessible from the other nodes in the cluster.
-Do this once per node:
-
-In file etc/vm.args  to -name couchdb@<this-nodes-ip-address> for each node.
-For clustered setup, each node in the system must have a unique name.
-
 In file etc/vm.args change the the line ``-name couchdb@127.0.0.1`` to
 ``-name couchdb@<this-nodes-ip-address| FQDN>`` for each node which defines
 the node and must be seperate for each node. For clustered setup, each node in
-system must have a unique name.Can also be a valid FQDN not necessarily the IP.
+system must have a unique name. Can also be a valid FQDN not necessarily the IP.
+
+Before you can add nodes to form a cluster, you must have them listening on an
+IP address accessible from the other nodes in the cluster.
+Do this once per node:
 
 .. code-block:: bash
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -231,17 +231,25 @@ following command to complete the setup and add the missing databases:
 
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "finish_cluster"}'
 
-Verify install
+Verify install:
+
 .. code-block:: bash
     curl http://admin:password@127.0.0.1:5984/_cluster_setup
-Response
+
+Response:
+
 .. code-block:: bash
     {"state":"cluster_finished"}
 
-Verify cluster nodes
+
+Verify cluster nodes:
+
 .. code-block:: bash
+
     curl http://admin:password@127.0.0.1:5984/_membership
-Response
+
+Response:
+
 .. code-block:: bash
     {
     "all_nodes": [

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -166,11 +166,12 @@ expect to add to the cluster before adding nodes.
 Before you can add nodes to form a cluster, you must have them listening on an
 IP address accessible from the other nodes in the cluster. Do this once per node:
 
-In file etc/vm.args  to -name couchdb@<this-nodes-ip-address> for each node. For clustered setup, each node in the system must have a unique name.
+In file etc/vm.args  to -name couchdb@<this-nodes-ip-address> for each node. For
+clustered setup, each node in the system must have a unique name.
 
-In file etc/vm.args change the the line ``-name couchdb@127.0.0.1`` to 
-``-name couchdb@<this-nodes-ip-address| FQDN>`` for each node which defines 
-the node and must be seperate for each node. For clustered setup, each node in 
+In file etc/vm.args change the the line ``-name couchdb@127.0.0.1`` to
+``-name couchdb@<this-nodes-ip-address| FQDN>`` for each node which defines
+the node and must be seperate for each node. For clustered setup, each node in
 system must have a unique name.Can also be a valid FQDN not necessarily the IP.
 
 .. code-block:: bash

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -234,11 +234,13 @@ following command to complete the setup and add the missing databases:
 Verify install:
 
 .. code-block:: bash
+
     curl http://admin:password@127.0.0.1:5984/_cluster_setup
 
 Response:
 
 .. code-block:: bash
+
     {"state":"cluster_finished"}
 
 
@@ -251,16 +253,17 @@ Verify cluster nodes:
 Response:
 
 .. code-block:: bash
+
     {
-    "all_nodes": [
-        "couchdb@couch1",
-        "couchdb@couch2",
-    ],
-    "cluster_nodes": [
-        "couchdb@couch1",
-        "couchdb@couch2",
-    ]
-}
+        "all_nodes": [
+            "couchdb@couch1",
+            "couchdb@couch2",
+        ],
+        "cluster_nodes": [
+            "couchdb@couch1",
+            "couchdb@couch2",
+        ]
+    }
 
 You CouchDB cluster is now set up.
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -167,8 +167,8 @@ Before you can add nodes to form a cluster, you have to have them
 listen on a public IP address and set up an admin user. Do this, once
 per node:
 
-Change line ``-name couchdb@127.0.0.1`` in file etc/vm.args on
-each node for clustered setup, each node in system must have a unique name.
+``-name couchdb@127.0.0.1`` in file etc/vm.args on
+For clustered setup, each node in system must have a unique name.
 
 .. code-block:: bash
 

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -218,7 +218,6 @@ To add a node run these commands for each node you want to add:
 
 .. code-block:: bash
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "enable_cluster", "bind_address":"0.0.0.0", "username": "admin", "password":"password", "port": 15984, "node_count": "3", "remote_node": "<remote-node-ip>", "remote_current_user": "<remote-node-username>", "remote_current_password": "<remote-node-password>" }'
-    
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "add_node", "host":"<remote-node-ip>", "port": <remote-node-port>, "username": "admin", "password":"password"}'
 
 This will join the two nodes together.

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -164,10 +164,11 @@ procedure on other machines. Be sure to specify the total number of nodes you
 expect to add to the cluster before adding nodes.
 
 Before you can add nodes to form a cluster, you must have them listening on an
-IP address accessible from the other nodes in the cluster. Do this once per node:
+IP address accessible from the other nodes in the cluster.
+Do this once per node:
 
-In file etc/vm.args  to -name couchdb@<this-nodes-ip-address> for each node. For
-clustered setup, each node in the system must have a unique name.
+In file etc/vm.args  to -name couchdb@<this-nodes-ip-address> for each node.
+For clustered setup, each node in the system must have a unique name.
 
 In file etc/vm.args change the the line ``-name couchdb@127.0.0.1`` to
 ``-name couchdb@<this-nodes-ip-address| FQDN>`` for each node which defines

--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -167,6 +167,7 @@ Before you can add nodes to form a cluster, you have to have them
 listen on a node address if all nodes can communicate over those IP's,
 also set up an admin user which should be same on all nodes. Do this, once
 per node:
+
 In file etc/vm.args 
 ``-name couchdb@<this-nodes-ip-address| FQDN>`` which defines the node and must
 be seperate for each node. For clustered setup, each node in system must have a


### PR DESCRIPTION
- When doing cluster_setup via api or wizard we need to make changes in vm.args as all nodes should have a unique name (mentioned in the file comments but not in the cluster setup documentation)
- executing _cluster_setup api with enable_cluster the second time gives error response on the coordination node when adding nodes to cluster hence is not required causes failure
- only add_node action is required from _cluster_setup api on  coordination node
- Added cluster setup verification docs