### PR TITLE
Use the correct module for cookie and default auth

### DIFF
--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -280,7 +280,7 @@ Proxy Authentication
     .. code-block:: ini
 
         [chttpd]
-        authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+        authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
 `Proxy authentication` is very useful in case your application already uses
 some external authentication service and you don't want to duplicate users and

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -283,11 +283,11 @@ HTTP Server Options
         let users to use one of provided methods::
 
             [chttpd]
-            authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+            authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
-        - ``{couch_httpd_auth, cookie_authentication_handler}``: used for Cookie auth;
+        - ``{chttpd_auth, cookie_authentication_handler}``: used for Cookie auth;
         - ``{couch_httpd_auth, proxy_authentication_handler}``: used for Proxy auth;
-        - ``{couch_httpd_auth, default_authentication_handler}``: used for Basic auth;
+        - ``{chttpd_auth, default_authentication_handler}``: used for Basic auth;
         - ``{couch_httpd_auth, null_authentication_handler}``: disables auth.
           Everlasting `Admin Party`!
 


### PR DESCRIPTION
## Overview

In CouchDB 2.0 we moved to chttpd for the cookie and default authentication handlers. We updated most of the documentation but overlooked the part where we advised folks on the configuration of custom handlers. This fixes that oversight.

## GitHub issue number

See apache/couchdb#1054
