### PR TITLE
Adding osx dependencie issue to documentation

### DIFF
--- a/src/install/troubleshooting.rst
+++ b/src/install/troubleshooting.rst
@@ -275,3 +275,15 @@ the relevant CouchDB and then compact prior to replicating.
 
 Alternatively, if the number of documents impacted is small, use filtered
 replication to exclude only those documents.
+
+Mac Os Known Issues
+====================
+undefined error, exit_status 134
+--------------------------------
+
+Sometimes the ``Verify Installation`` fails with an ``undefined`` error.  
+This could be due to a missing dependency with Mac.  
+In the logs, you will find ``couchdb exit_status,134``.  
+
+If so, installing the missing ``nspr`` via ``brew install nspr`` should resolve the issue.  
+(related issue: https://github.com/apache/couchdb/issues/979)

--- a/src/install/troubleshooting.rst
+++ b/src/install/troubleshooting.rst
@@ -276,7 +276,7 @@ the relevant CouchDB and then compact prior to replicating.
 Alternatively, if the number of documents impacted is small, use filtered
 replication to exclude only those documents.
 
-Mac Os Known Issues
+macOS Known Issues
 ====================
 undefined error, exit_status 134
 --------------------------------

--- a/src/install/troubleshooting.rst
+++ b/src/install/troubleshooting.rst
@@ -281,9 +281,9 @@ Mac Os Known Issues
 undefined error, exit_status 134
 --------------------------------
 
-Sometimes the ``Verify Installation`` fails with an ``undefined`` error.  
-This could be due to a missing dependency with Mac.  
-In the logs, you will find ``couchdb exit_status,134``.  
+Sometimes the ``Verify Installation`` fails with an ``undefined`` error.
+This could be due to a missing dependency with Mac.
+In the logs, you will find ``couchdb exit_status,134``.
 
-If so, installing the missing ``nspr`` via ``brew install nspr`` should resolve the issue.  
-(related issue: https://github.com/apache/couchdb/issues/979)
+Installing the missing ``nspr`` via ``brew install nspr`` resolves the issue.
+(see: https://github.com/apache/couchdb/issues/979)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

There is this issue with the missing dependency. How about adding the workaround to the documentation until resolved.

## GitHub issue number

#979 (https://github.com/apache/couchdb/issues/979)

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
