### PR TITLE
added header info to replication api

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -486,6 +486,9 @@
       should occur (protocol can be "http" or "socks5")
     :<json string source: Source database name or URL
     :<json string target: Target database name or URL
+    :<json object headers: Object with header info in key value pairs.
+      Eg: {"Authorization": "Basic Ym9iQGV4YW1wbGUuY29tOnBhc3N3b3Jk",
+      "header_name_2": "header_value_2",...}.
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
     :>json array history: Replication history (see below)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Replication between 2 couchdb nodes with custom headers is implemented, but not present in the documentation. This commit adds that.

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
