### PR TITLE
fixed source and target database instructions in the replication api

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -484,11 +484,16 @@
     :<json string filter: The name of a :ref:`filter function <filterfun>`.
     :<json string proxy: Address of a proxy server through which replication
       should occur (protocol can be "http" or "socks5")
-    :<json string source: Source database name or URL
-    :<json string target: Target database name or URL
-    :<json object headers: Object with header info in key value pairs.
-      Eg: {"Authorization": "Basic Ym9iQGV4YW1wbGUuY29tOnBhc3N3b3Jk",
-      "header_name_2": "header_value_2",...}.
+    :<json string/object source: Source database name or URL or an object
+      which contains the full URL of the source database with additional
+      parameters like headers. Eg: 'source_db_name' or
+      'http://example.com/source_db_name' or
+      {"url":"url in here", "headers": {"header1":"value1", ...}}
+    :<json string/object target: Target database name or URL or an object
+      which contains the full URL of the target database with additional
+      parameters like headers. Eg: 'target_db_name' or
+      'http://example.com/target_db_name' or
+      {"url":"url in here", "headers": {"header1":"value1", ...}}
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
     :>json array history: Replication history (see below)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Fixed the incorrect headers documentation I added in the replication api

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
