### PR TITLE
fix(typo): fix a typo in setup.rst

### DIFF
--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -227,7 +227,7 @@ following command to complete the setup and add the missing databases:
 
     curl -X POST -H "Content-Type: application/json" http://admin:password@127.0.0.1:5984/_cluster_setup -d '{"action": "finish_cluster"}'
 
-You CouchDB cluster is now set up.
+Your CouchDB cluster is now set up.
 
 .. _HAProxy: http://haproxy.org/
 .. _example configuration for HAProxy: https://github.com/apache/couchdb/blob/master/rel/haproxy.cfg


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This pull request fixes a typo in the cluster/setup.rst file where a `r` was missing from `Your CouchDB cluster` and it said `You CouchDB cluster`. This will give users a better user experience while they read through the documentation.

I created the PR because I read the documentation and was confused by that sentence and I cared enough about it to create a Pull Request so that other users will have a better experience then I did.

## Checklist

- [x] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
