### PR TITLE
Use the correct node-local port

### DIFF
--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -95,7 +95,7 @@ HTTP Server Options
         Defines the port number to listen::
 
             [httpd]
-            port = 5984
+            port = 5986
 
         To let CouchDB use any free port, set this option to ``0``::
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Document the correct node-local port.

## Checklist

- [ ] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
