### PR TITLE
Suggested edit to make clear what a quorum actually represents.

### DIFF
--- a/src/cluster/theory.rst
+++ b/src/cluster/theory.rst
@@ -34,10 +34,17 @@ thereby override the defaults in ``default.ini``.
 
 The number of copies of a document with the same revision that have to be read
 before CouchDB returns with a ``200`` is equal to a half of total copies of
-the document plus one. It is the same for the number of nodes that need to
-save a document before a write is returned with ``201``. If there are less
-nodes than that number, then ``202`` is returned. Both read and write numbers
-can be specified with a request as ``r`` and ``w`` parameters accordingly.
+the document plus one *in the current partition*. That is, if there is a network
+partition and, for example, only 1 out of 3 nodes is available you can still
+get a ``200`` response but the data will not have come from a true quorum and
+might be stale.
+
+The number of nodes that need to save a document before a write is returned with
+``201`` is also equal to half of the total copies of the document plus one.
+However, unlike the read case, for writes this is computed for the database as a
+whole, even if there is a network partition. If there are less nodes than that
+number, then ``202`` is returned. Both read and write numbers can be specified
+with a request as ``r`` and ``w`` parameters accordingly.
 
 We will focus on the shards and replicas for now.
 

--- a/src/cluster/theory.rst
+++ b/src/cluster/theory.rst
@@ -32,10 +32,10 @@ As you see in ``etc/default.ini`` there is a section called [cluster]
 When creating a database you can send your own values with request and
 thereby override the defaults in ``default.ini``.
 
-In clustered operation, a quorum must be reached before CouchDB returns a 200
-for a fetch, or 201 for a write operation. A quorum is defined one plus half the
-number of "relevant copies". "Relevant copies" is defined slightly differently
-for read and write operations.
+In clustered operation, a quorum must be reached before CouchDB returns a
+``200`` for a fetch, or 201 for a write operation. A quorum is defined as one
+plus half the number of "relevant copies". "Relevant copies" is defined
+slightly differently for read and write operations.
 
 For read operations, the number of relevant copies is the number of
 currently-accessible shards holding the requested data, meaning that in the case
@@ -44,7 +44,7 @@ than the number of replicas in the cluster.  The number of read copies can be
 set with the rparameter.
 
 For write operations the number of relevant copies is always `n`, the number of
-replicas in teh cluster.  For write operations, the number of copies can be set
+replicas in the cluster.  For write operations, the number of copies can be set
 using the w parameter. If fewer than this number of nodes is available, a 202
 will be returned.
 

--- a/src/cluster/theory.rst
+++ b/src/cluster/theory.rst
@@ -42,7 +42,7 @@ might be stale.
 The number of nodes that need to save a document before a write is returned with
 ``201`` is also equal to half of the total copies of the document plus one.
 However, unlike the read case, for writes this is computed for the database as a
-whole, even if there is a network partition. If there are less nodes than that
+whole, even if there is a network partition. If there are fewer nodes than that
 number, then ``202`` is returned. Both read and write numbers can be specified
 with a request as ``r`` and ``w`` parameters accordingly.
 

--- a/src/cluster/theory.rst
+++ b/src/cluster/theory.rst
@@ -32,19 +32,21 @@ As you see in ``etc/default.ini`` there is a section called [cluster]
 When creating a database you can send your own values with request and
 thereby override the defaults in ``default.ini``.
 
-The number of copies of a document with the same revision that have to be read
-before CouchDB returns with a ``200`` is equal to a half of total copies of
-the document plus one *in the current partition*. That is, if there is a network
-partition and, for example, only 1 out of 3 nodes is available you can still
-get a ``200`` response but the data will not have come from a true quorum and
-might be stale.
+In clustered operation, a quorum must be reached before CouchDB returns a 200
+for a fetch, or 201 for a write operation. A quorum is defined one plus half the
+number of "relevant copies". "Relevant copies" is defined slightly differently
+for read and write operations.
 
-The number of nodes that need to save a document before a write is returned with
-``201`` is also equal to half of the total copies of the document plus one.
-However, unlike the read case, for writes this is computed for the database as a
-whole, even if there is a network partition. If there are fewer nodes than that
-number, then ``202`` is returned. Both read and write numbers can be specified
-with a request as ``r`` and ``w`` parameters accordingly.
+For read operations, the number of relevant copies is the number of
+currently-accessible shards holding the requested data, meaning that in the case
+of a failure or network partition, the number of relevant copies may be lower
+than the number of replicas in the cluster.  The number of read copies can be
+set with the rparameter.
+
+For write operations the number of relevant copies is always `n`, the number of
+replicas in teh cluster.  For write operations, the number of copies can be set
+using the w parameter. If fewer than this number of nodes is available, a 202
+will be returned.
 
 We will focus on the shards and replicas for now.
 


### PR DESCRIPTION
## Overview

I found the documentation about read and write quorums for a cluster mode DB confusing. I think this edit makes things a bit more clear (though I don't love the wording).

This came from a Slack conversation which you can find here if curious: https://couchdb.slack.com/archives/C49LEE7NW/p1519761842000347
