### PR TITLE
Replication plugin and session support

### DIFF
--- a/src/config/replicator.rst
+++ b/src/config/replicator.rst
@@ -211,3 +211,21 @@ Replicator Database Configuration
 
             [replicator]
             ssl_certificate_max_depth = 3
+
+    .. config:option:: auth_plugins
+
+        .. versionadded:: 2.2
+
+        List of replicator client authentication plugins. Plugins will
+        be tried in order and the first to initialize successfully will
+        be used. By default there are two plugins available:
+        `couch_replicator_auth_session` implementing session (cookie)
+        authentication, and `couch_replicator_auth_noop` implementing basic
+        authentication. For backwards compatibility, the no-op plugin should be used at
+        the end of the plugin list::
+
+          [replicator]
+          auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
+
+        .. note::
+             In version 2.2, the session plugin is considered experimental and is not enabled by default.

--- a/src/whatsnew/2.2.rst
+++ b/src/whatsnew/2.2.rst
@@ -1,0 +1,36 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. _release/2.2.x:
+
+============
+2.2.x Branch
+============
+
+.. contents::
+    :depth: 1
+    :local:
+
+Version 2.2.0
+=============
+
+General
+-------
+
+* :ghissue:`1153`: Plugin based replicator authentication support. Session
+  (cookie) based authentication implemented in the
+  `couch_replicator_auth_session` plugin module. In this release session based
+  authentication is considered experimental and is disabled by default. To
+  enable set `[replicator] auth_plugins =
+  couch_replicator_auth_session,couch_replicator_auth_noop`. Consider enabling
+  it when using PBKDF2 or the new bcrypt password hashing algorithm with a
+  large work factor.

--- a/src/whatsnew/index.rst
+++ b/src/whatsnew/index.rst
@@ -19,6 +19,7 @@ Release History
 .. toctree::
     :glob:
 
+    2.2
     2.1
     2.0
     1.7


### PR DESCRIPTION
New `auth_plugins` section in config API

Mention experimental session plugin status in whatsnew for 2.2.x
