### PR TITLE
Fix whitespace in bulleted lists

### DIFF
--- a/static/css/rtd_theme.css
+++ b/static/css/rtd_theme.css
@@ -47,3 +47,10 @@ span.linkdescr {
     font-size: 90%;
 }
 
+/* https://github.com/rtfd/sphinx_rtd_theme/pull/591/files and
+   https://github.com/rtfd/sphinx_rtd_theme/issues/590 */
+
+.rst-content .section ol li p:last-child,
+.rst-content .section ul li p:last-child {
+    margin-bottom: 24px !important;
+}


### PR DESCRIPTION
Fixes #201.

Note that, in my testing, prefixing the list with:

```rst
.. rst-class:: open
```

may be necessary to force the double-spacing, especially if the list is not internally double-spaced already, or has lines that are only one line long.