### PR TITLE
Document seq_interval parameter

### DIFF
--- a/src/api/database/changes.rst
+++ b/src/api/database/changes.rst
@@ -212,7 +212,7 @@
 .. note::
     Cloudant Sync and PouchDB already optimize the replication process by
     setting ``seq_interval`` parameter to the number of results expected per
-    batch. This parameter increase throughput by reducing latency between
+    batch. This parameter increases throughput by reducing latency between
     sequential requests in bulk document transfers. This has resulted in up to
     a 20% replication performance improvement in highly-sharded databases.
 

--- a/src/api/database/changes.rst
+++ b/src/api/database/changes.rst
@@ -102,6 +102,13 @@
         counted as "passed" for view filter in case if map function emits
         at least one record for them.
         See :ref:`changes/filter/view` for more info.
+    :query number seq_interval: When fetching changes in a batch, setting the
+        *seq_interval* parameter tells CouchDB to only calculate the update seq
+        with every Nth result returned. By setting **seq_interval=<batch size>**
+        , where ``<batch size>`` is the number of results requested per batch,
+        load can be reduced on the source CouchDB database; computing the seq
+        value across many shards (esp. in highly-sharded databases) is expensive
+        in a heavily loaded CouchDB cluster.
     :>header Cache-Control: ``no-cache`` if changes feed is
         :ref:`eventsource <changes/eventsource>`
     :>header Content-Type: - :mimetype:`application/json`
@@ -191,7 +198,8 @@
 .. versionchanged:: 1.4.0 Support ``Last-Event-ID`` header.
 .. versionchanged:: 1.6.0 added ``attachments`` and ``att_encoding_info``
    parameters
-.. versionchanged:: 2.0.0 update sequences can be any valid json object
+.. versionchanged:: 2.0.0 update sequences can be any valid json object,
+   added ``seq_interval``
 
 .. note::
     If the specified replicas of the shards in any given since value are
@@ -200,6 +208,13 @@
     again that you have previously seen. Therefore, an application making use
     of the `_changes` feed should be ‘idempotent’, that is, able to receive the
     same data multiple times, safely.
+
+.. note::
+    Cloudant Sync and PouchDB already optimize the replication process by
+    setting ``seq_interval`` parameter to the number of results expected per
+    batch. This parameter increase throughput by reducing latency between
+    sequential requests in bulk document transfers. This has resulted in up to
+    a 20% replication performance improvement in highly-sharded databases.
 
 .. warning::
     Using the ``attachments`` parameter to include attachments in the changes


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Added the seq_interval parameter description as suggested by @wohali  in #230 with minor changes.
A note has been added referencing the improvement gained by other projects when using this parameter

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number
This PR fixes #230 
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [X] Documentation is written and is accurate;
- [X] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
