### PR TITLE
Fix _local_docs examples and remove ETAG references

### DIFF
--- a/src/api/local.rst
+++ b/src/api/local.rst
@@ -104,7 +104,6 @@ A list of the available methods and URL paths are provided below:
       reflects. Default is ``false``.
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
-    :>header ETag: Response signature
     :>json number offset: Offset where the design document list started
     :>json array rows: Array of view row objects. By default the information
       returned contains only the design document ID and revision.
@@ -129,12 +128,11 @@ A list of the available methods and URL paths are provided below:
         Cache-Control: must-revalidate
         Content-Type: application/json
         Date: Sat, 23 Dec 2017 16:22:56 GMT
-        ETag: "1W2DJUZFZSZD9K78UFA3GZWB4"
         Server: CouchDB (Erlang/OTP)
         Transfer-Encoding: chunked
 
         {
-            "offset": 0,
+            "offset": null,
             "rows": [
                 {
                     "id": "_local/localdoc01",
@@ -172,7 +170,7 @@ A list of the available methods and URL paths are provided below:
                     }
                 }
             ],
-            "total_rows": 5
+            "total_rows": null
         }
 
 .. http:post:: /{db}/_local_docs
@@ -208,7 +206,7 @@ A list of the available methods and URL paths are provided below:
     .. code-block:: javascript
 
         {
-            "total_rows" : 5,
+            "total_rows" : null,
             "rows" : [
                 {
                     "value" : {
@@ -225,7 +223,7 @@ A list of the available methods and URL paths are provided below:
                     "key" : "_local/localdoc05"
                 }
             ],
-            "offset" : 0
+            "offset" : null
         }
 
 ``/db/_local/id``


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR is an amend for PR #260 
- Corrects _local_docs example by setting offset and total_rows to null
- Removes ETAG references in _local_docs documentation

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [X] Documentation is written and is accurate;
- [X] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
