### PR TITLE
Add the POST _bulk_get endpoint

### DIFF
--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -497,14 +497,14 @@ Sending multiple queries to a database
             "docs": [
                 {
                     "id": "foo"
-                    "_rev": "4-753875d51501a6b1883a9d62b4d33f91",
+                    "rev": "4-753875d51501a6b1883a9d62b4d33f91",
                 },
                 {
                     "id": "foo"
-                    "_rev": "1-4a7e4ae49c4366eaed8edeaea8f784ad",
+                    "rev": "1-4a7e4ae49c4366eaed8edeaea8f784ad",
                 },
                 {
-                    "_id": "bar",
+                    "id": "bar",
                 }
             ]
         }

--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -465,20 +465,9 @@ Sending multiple queries to a database
 .. http:post:: /{db}/_bulk_get
     :synopsis: Fetches several documents at the given revision
 
-    This method is used by PouchDB and other client to improve the pull
-    replications, by allowing the client to request multiple documents in one
-    request.
-
-    The usual CouchDB API for bulk gets -- a POST to _all_docs with an array of
-    docIDs in the body -- isn't suitable for the replicator because:
-
-    - there's no way to specify which specific revisions are needed (it always
-      returns the default revision),
-    - the response doesn't contain the revision history,
-    - there's no way to specify that only recently changed attachments should
-      be included (a la ``atts_since``),
-    - and attachment bodies can only be encoded inline (base64) not as MIME
-      multipart bodies.
+    This method can be called to query several documents in a bulk. It is well
+    fitted when you want a specific revision of the documents, like replicators
+    do for example, or get the revision history.
 
     :param db: Database name
     :<header Accept: - :mimetype:`application/json`
@@ -490,6 +479,10 @@ Sending multiple queries to a database
     :>json object results: the documents, with the additionnal ``_revisions``
       property that lists the parent revisions if ``revs=true``
     :code 200: Request completed successfully
+    :code 400: The request provided invalid JSON data or invalid query parameter
+    :code 401: Read permission required
+    :code 404: Invalid database name
+    :code 415: Bad :header:`Content-Type` value
 
     **Request**:
 

--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -463,11 +463,11 @@ Sending multiple queries to a database
 ==================
 
 .. http:post:: /{db}/_bulk_get
-    :synopsis: Fetches several documents at the given revision
+    :synopsis: Fetches several documents at the given revisions
 
-    This method can be called to query several documents in a bulk. It is well
-    fitted when you want a specific revision of the documents, like replicators
-    do for example, or get the revision history.
+    This method can be called to query several documents in bulk. It is well
+    suited for fetching a specific revision of documents, as replicators do for
+    example, or for getting revision history.
 
     :param db: Database name
     :<header Accept: - :mimetype:`application/json`


### PR DESCRIPTION
## Overview

The POST _bulk_get endpoint was not documented, and not even listed in the API reference. I have added a short description with an example.

## Testing recommendations

The POST _bulk_get endpoint should appear in the API reference.

## GitHub issue number

Fixes #246

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
