### PR TITLE
Bump curl earlier in intro, fix for Windows

### DIFF
--- a/src/intro/curl.rst
+++ b/src/intro/curl.rst
@@ -51,6 +51,26 @@ clarity):
 
         shell> curl 'http://couchdb:5984/_uuids?count=5'
 
+.. lint: ignore errors for the next 15 lines
+
+.. note::
+    On Microsoft Windows, use double-quotes anywhere you see single-quotes in
+    the following examples. Use doubled double-quotes ("") anywhere you see
+    single quotes. For example, if you see:
+
+    .. code-block:: bash
+
+        shell> curl -X PUT 'http:/127.0.0.1:5984/demo/doc' -d '{"motto": "I love gnomes"}'
+
+    you should replace it with:
+
+    .. code-blocK:: bash
+
+        shell> curl -X PUT "http://127.0.0.1:5984/demo/doc" -d "{""motto"": ""I love gnomes""}"
+
+    If you prefer, ``^"`` and ``\"`` may be used to escape the double-quote
+    character in quoted strings instead.
+
 You can explicitly set the HTTP command using the ``-X`` command line option.
 For example, when creating a database, you set the name of the database in the
 URL you send using a PUT request:

--- a/src/intro/index.rst
+++ b/src/intro/index.rst
@@ -46,7 +46,7 @@ teach how to use CouchDB.
     overview
     why
     consistency
+    curl
     tour
     api
     security
-    curl


### PR DESCRIPTION
cURL should be explained before our first example that uses it.

On Windows, special escaping is required; explain the syntax necessary for beginners right at the start.