### PR TITLE
Callout the 4GB -> 64MB limit change

### DIFF
--- a/src/whatsnew/2.1.rst
+++ b/src/whatsnew/2.1.rst
@@ -58,6 +58,10 @@ Upgrade Notes
   :config:option:`couchdb/max_document_size` configuration parameter, which
   had been unfortunately misnamed, and has now been updated to behave as the
   name would suggest. Both are documented in the shipped ``default.ini`` file.
+  
+  Note that the default for this new parameter is 64MB instead of 4GB. If you get
+  errors when trying to PUT or POST and see HTTP 413 return codes in couchdb logs,
+  this could be the culprit. This can affect couchup in-place upgrades as well.
 
 * :ghissue:`914`: Certain critical config sections are blacklisted from being
   modified through the HTTP API. These sections can still be modified through


### PR DESCRIPTION


## Overview

Ran into an issue upgrading 1.6 to 2.1.1 in-place using couchup. The 1.6 DB had large design documents with many attachments and the upgrade was not successful as a result of a change in maximum size checking and a much lower default value. Our application was also affected as it attempted to make large requests. The upgrade notes highlighted the new parameter but did not describe the decrease in default value or how to identify an issue. The 413 HTTP code as a symptom of hitting the limit was only mentioned in the reference documentation for the parameter.

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
