### PR TITLE
Fix sphinx 1.7.5 build

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -22,7 +22,7 @@ Table of Contents
 =================
 .. toctree::
     :maxdepth: 3
-    :numbered: 3
+    :numbered:
 
     intro/index
     install/index


### PR DESCRIPTION
`:numbered: 3` was invalid and Sphinx had started to blow up there because
there were fixes to the that part of the code:

https://github.com/sphinx-doc/sphinx/pull/4998/files
