### PR TITLE
Document the couchdb/default_security configuration setting

### DIFF
--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -45,6 +45,13 @@ Base CouchDB Options
             [couchdb]
             database_dir = /var/lib/couchdb
 
+    .. config:option:: default_security :: Default security
+
+        Default security object for databases if not explicitly set. When set to ``everyone``, anyone can performs reads and writes. When set to ``admin_only``, only admins can read and write. When set to ``admin_local``, sharded databases can be read and written by anyone but the shards can only be read and written by admins.
+
+            [couchdb]
+            default_security = admin_local
+
     .. config:option:: delayed_commits :: Delayed commits
 
         When this config value is ``false`` the CouchDB provides a guarantee


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The `[couchdb] default_security` setting is not documented except in [the source](https://github.com/apache/couchdb/blob/master/rel/overlay/etc/default.ini#L26-L31), so I wrote this patch.

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
