### PR TITLE
Configure cluster Erlang port range using vm.args

### DIFF
--- a/src/cluster/setup.rst
+++ b/src/cluster/setup.rst
@@ -119,31 +119,16 @@ To close the shells, run in both:
 Make CouchDB use the open ports.
 --------------------------------
 
-Open ``sys.config``, on all nodes, and add ``inet_dist_listen_min, 9100`` and
-``inet_dist_listen_max, 9200`` like below:
+Open ``vm.args``, on all nodes, and add ``-kernel inet_dist_listen_min 9100``
+and ``-kernel inet_dist_listen_max 9200`` like below:
 
 .. code-block:: erlang
 
-    [
-        {lager, [
-            {error_logger_hwm, 1000},
-            {error_logger_redirect, true},
-            {handlers, [
-                {lager_console_backend, [debug, {
-                    lager_default_formatter,
-                    [
-                        date, " ", time,
-                        " [", severity, "] ",
-                        node, " ", pid, " ",
-                        message,
-                        "\n"
-                    ]
-                }]}
-            ]},
-            {inet_dist_listen_min, 9100},
-            {inet_dist_listen_max, 9200}
-        ]}
-    ].
+    -name ...
+    -setcookie ...
+    ...
+    -kernel inet_dist_listen_max 9100
+    -kernel inet_dist_listen_max 9200
 
 .. _cluster/setup/wizard:
 


### PR DESCRIPTION
Ports specified in sys.config as per previous documentation seem to be ignored by CouchDB

## Overview

Current documentation suggests putting the distributed Erlang port range restriction in `sys.config`, however in my experience this does not get picked up by CouchDB. What works for me is specifying the port range in `vm.args` instead.  I am using a recent build from source (`62f71c0b0`).

I am aware I may not be putting `sys.config` in the correct place to be picked up by CouchDB - if that's the case and modifying `sys.config` works for you then let me know and I will change the PR to simply clarify the correct location for `sys.config`. 

## Testing recommendations

## GitHub issue number

## Related Pull Requests

## Checklist

- [x ] Documentation is written and is accurate;
- [x ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
