### PR TITLE
Update 2.2.rst

### DIFF
--- a/src/whatsnew/2.2.rst
+++ b/src/whatsnew/2.2.rst
@@ -27,7 +27,7 @@ Upgrade Notes
 
 .. rst-class:: open
 
-* The minimum supported version of Erlang is now R17, not 16B03. Support for Erlang 21
+* The minimum supported version of Erlang is now 17, not R16B03. Support for Erlang 21
   is still ongoing and will be provided in a future release.
 
 * The CouchDB replication client can now use the ``/_session`` endpoint when


### PR DESCRIPTION
Erlang release names dropped the R prefix after 17

