### PR TITLE
Document 'POST /_node/{node-name}/_restart'

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -1492,6 +1492,20 @@ containing only the requested individual statistic.
 
     These statistics are generally intended for CouchDB developers only.
 
+.. _api/server/restart:
+
+===============================
+``/_node/{node-name}/_restart``
+===============================
+
+.. http:post:: /_node/{node-name}/_restart
+    :synopsis: Restarts CouchDB application on a given node
+
+    This API is to facilitate integration testing only
+    it is not meant to be used in production
+
+    :code 200: Request completed successfully
+
 .. _api/server/utils:
 
 ===========

--- a/src/api/server/configuration.rst
+++ b/src/api/server/configuration.rst
@@ -129,7 +129,6 @@ interact with the local node's configuration.
                 "_all_dbs": "{couch_httpd_misc_handlers, handle_all_dbs_req}",
                 "_config": "{couch_httpd_misc_handlers, handle_config_req}",
                 "_replicate": "{couch_httpd_misc_handlers, handle_replicate_req}",
-                "_restart": "{couch_httpd_misc_handlers, handle_restart_req}",
                 "_session": "{couch_httpd_auth, handle_session_req}",
                 "_stats": "{couch_httpd_stats_handlers, handle_stats_req}",
                 "_utils": "{couch_httpd_misc_handlers, handle_utils_dir_req, \"/usr/share/couchdb/www\"}",

--- a/src/config/http-handlers.rst
+++ b/src/config/http-handlers.rst
@@ -80,13 +80,6 @@ Global HTTP Handlers
             [httpd_global_handlers]
             _replicate = {couch_replicator_httpd, handle_req}
 
-    .. config:option:: _restart
-
-        Provides an API to restart CouchDB (only on the node-local port).
-
-            [httpd_global_handlers]
-            _restart = {couch_httpd_misc_handlers, handle_restart_req}
-
     .. config:option:: _session
 
         Provides a resource with information about the current user's session::

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -70,8 +70,8 @@ identification for certain requests:
   </{db}/_design/{ddoc}>`)
 - Triggering compaction (:post:`POST /database/_compact </{db}/_compact>`)
 - Reading the task status list (:get:`GET /_active_tasks </_active_tasks>`)
-- Restarting the server on the node-local port
-  (:post:`POST /_restart </_restart>`)
+- Restarting the server on a given node
+  (:post:`POST /_node/{node-name}/_restart </_restart>`)
 - Reading the active configuration
   (:get:`GET /_node/{node-name}/_config </_config>`)
 - Updating the active configuration


### PR DESCRIPTION
## Overview

We need to be able to restart CouchDB from integration test suite.
We used to have this feature, but it was removed.
This PR documents `/_node/$node/_restart` endpoint implemented in 
https://github.com/apache/couchdb/pull/1543.

## Testing recommendations

## GitHub issue number

## Related Pull Requests

https://github.com/apache/couchdb/pull/1543

## Checklist

- [x] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
