### PR TITLE
Include info on JS transpilation with link to Babel's repl-editor

### DIFF
--- a/src/best-practices/jsdevel.rst
+++ b/src/best-practices/jsdevel.rst
@@ -26,6 +26,13 @@ tips and tricks that will ease the difficulty.
   ECMA-262 5th edition ("ES5") of the language. ES6/2015 and newer constructs
   cannot be used.
 
+  Fortunately, there are many tools available for transpiling modern JavaScript
+  into code compatible with older JS engines. The `Babel Project website
+  <http://babeljs.io/repl>`_, for example, offers an in-browser text editor
+  which transpiles JavaScript in real-time. Configuring CouchDB-compatibility
+  is as easy as enabling the ``ENV PRESET`` option, and typing "firefox 4.0"
+  into the *Browsers* field.
+
 - The ``log()`` function will log output to the CouchDB log file or stream.
   You can log strings, objects, and arrays directly, without first converting
   to JSON.  Use this in conjunction with a local CouchDB instance for best


### PR DESCRIPTION
## Overview

This PR provides hope to developers learning of CouchDB's antique JavaScript engine, and the ancient JS dialect required therefore. 

Transpiling modern JavaScript for e.g. backwards browser compatibility is so common these days that it's arguably a fundamental skill for any front-end developer. The tooling and config that's needed, however, is NOT beginner-friendly, and so a link is provided to [Babel's in-browser real-time-transpilation text editing tool](http://babeljs.io/repl), as well as 2-step instructions on how to target the JavaScript version required by CouchDB's engine. 

In short, it informs users that modern JavaScript **can** be used, albeit with a little step in between.

## Testing recommendations

N/A

## GitHub issue number

N/A

## Related Pull Requests

N/A

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
