### PR TITLE
Fix version for rewrites as a function

### DIFF
--- a/src/api/ddoc/rewrites.rst
+++ b/src/api/ddoc/rewrites.rst
@@ -28,8 +28,9 @@
 Using a stringified function for ``rewrites``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    *The 'Rewrite using JS' feature was introduced in CouchDB 2.x*. When the
-    ``rewrites`` field is a stringified function, the query server is used
+.. versionadded:: 2.0
+
+    When the ``rewrites`` field is a stringified function, the query server is used
     to pre-process and route requests.
 
     The function takes a :ref:`request2_object`.

--- a/src/best-practices/jsdevel.rst
+++ b/src/best-practices/jsdevel.rst
@@ -26,6 +26,13 @@ tips and tricks that will ease the difficulty.
   ECMA-262 5th edition ("ES5") of the language. ES6/2015 and newer constructs
   cannot be used.
 
+  Fortunately, there are many tools available for transpiling modern JavaScript
+  into code compatible with older JS engines. The `Babel Project website
+  <http://babeljs.io/repl>`_, for example, offers an in-browser text editor
+  which transpiles JavaScript in real-time. Configuring CouchDB-compatibility
+  is as easy as enabling the ``ENV PRESET`` option, and typing "firefox 4.0"
+  into the *Browsers* field.
+
 - The ``log()`` function will log output to the CouchDB log file or stream.
   You can log strings, objects, and arrays directly, without first converting
   to JSON.  Use this in conjunction with a local CouchDB instance for best


### PR DESCRIPTION
Follow-up to https://github.com/apache/couchdb/issues/1410

I'm not sure which specific version of CouchDB rewrites-as-a-function was introduced, but it was sometime after CouchDB 2.0.0--hence the `2.x` moniker.

Updated it if you need more accuracy. 😄 

Cheers!
🎩 