### PR TITLE
correct the note about replicator/auth_plugins

### DIFF
--- a/src/config/replicator.rst
+++ b/src/config/replicator.rst
@@ -229,4 +229,4 @@ Replicator Database Configuration
           auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
 
         .. note::
-             In version 2.2, the session plugin is considered experimental and is not enabled by default.
+             In version 2.2.0, the session plugin is enabled by default and may break replication with peers using `require_valid_user`.


### PR DESCRIPTION
## Overview

The session authentication plugin is actually enabled in 2.2.0 and breaks existing replications with peers using `require_valid_user`.

## Testing recommendations

Documentations updates should be tested.

## GitHub issue number

Fixes #319

## Related Pull Requests

none

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
