### PR TITLE
Added the number of Replicas to the Put {db} call

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -154,6 +154,8 @@
     :param db: Database name
     :query integer q: Shards, aka the number of range partitions. Default is
       8, unless overridden in the :config:option:`cluster config <cluster/q>`.
+    :query integer n: Replicas. The number of copies of every document. Default
+      is 3, unless overridden in the :config:option:`cluster config <cluster/q>`.  
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`text/plain`
     :>header Content-Type: - :mimetype:`application/json`


### PR DESCRIPTION
The query parameter `n` for the number of Replicas was missing in the `PUT {db}` REST call.

## Checklist

- [x] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
