### PR TITLE
added missing semicolon in code example list

### DIFF
--- a/src/ddocs/ddocs.rst
+++ b/src/ddocs/ddocs.rst
@@ -464,7 +464,7 @@ HTML page:
             }
         });
         send('<html><body><table>');
-        send('<tr><th>ID</th><th>Key</th><th>Value</th></tr>')
+        send('<tr><th>ID</th><th>Key</th><th>Value</th></tr>');
         while(row = getRow()){
             send(''.concat(
                 '<tr>',


### PR DESCRIPTION
missing semicolon before while loop.

##Overview
added missing semicolon before while loop in code example for list functions in the design document documentation.

without this semicolon compilation error will occur:
{"error":"compilation_error","reason":"Expression does not eval to a function. (...)}

##Testing recommendations
try copy pasting and minifying via for example at https://www.minifier.org/, write code directly into ddoc list function.