### PR TITLE
Update responses and UI copy in Getting Started Guide

### DIFF
--- a/src/intro/tour.rst
+++ b/src/intro/tour.rst
@@ -41,10 +41,15 @@ The reply should look something like:
 
     {
         "couchdb": "Welcome",
+        "version": "2.2.0",
+        "git_sha":"2a16ec4",
+        "features": [
+            "pluggable-storage-engines",
+            "scheduler"
+        ],
         "vendor": {
             "name": "The Apache Software Foundation"
-        },
-        "version": "2.0.0"
+        }
     }
 
 Not all that spectacular. CouchDB is saying "hello" with the running version
@@ -58,7 +63,7 @@ All we added to the previous request is the _all_dbs string.
 
 The response should look like::
 
-    ["_replicator","_users"]
+    []
 
 Oh, that's right, we didn't create any databases yet! All we see is an empty
 list.
@@ -335,7 +340,7 @@ Edit the map function, on the right, so that it looks like the following:
 This is a JavaScript function that CouchDB runs for each of our documents as
 it computes the view. We'll leave the reduce function blank for the time being.
 
-Click "Run" and you should see result rows,
+Click "Save Document and then Build Index" and you should see result rows,
 with the various items sorted by price. This map function could be even more
 useful if it grouped the items by type so that all the prices for bananas were
 next to each other in the result set. CouchDB's key sorting system allows any


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

I just gave the Getting Started Guide a go and noticed that some of the responses and UI elements that are being referred to are out of sync with a fresh 2.2.0 installation. This PR syncs the document with the values returned / used.

## Testing recommendations

Run a fresh install of CouchDB 2.2.0, then do what is described in the Getting Started Guide.

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
