### PR TITLE
Fix `make check` failure in api/database/common.rst

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -154,7 +154,9 @@
     :param db: Database name
     :query integer q: Shards, aka the number of range partitions. Default is
       8, unless overridden in the :config:option:`cluster config <cluster/q>`.
-    :query integer n: Replicas. The number of copies of the database in the cluster. The default is 3, unless overridden in the :config:option:`cluster config <cluster/n>` .
+    :query integer n: Replicas. The number of copies of the database in the
+      cluster. The default is 3, unless overridden in the
+      :config:option:`cluster config <cluster/n>` .
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`text/plain`
     :>header Content-Type: - :mimetype:`application/json`


### PR DESCRIPTION
```
line 158 : too long (173 > 90) line
    :query integer n: Replicas. The number of copies of the database in the cluster. The default is 3, unless overridden in the :config:option:`cluster config <cluster/n>` .
```

This passes make check locally on MacOS but fails in Travis somehow.

Even stranger, it passed in Travis before when it was PR
