### PR TITLE
Remove broken links to wiki.apache.org

### DIFF
--- a/src/ddocs/ddocs.rst
+++ b/src/ddocs/ddocs.rst
@@ -429,10 +429,6 @@ the `xml` provider in our function needs more care to handle nested objects
 correctly, and keys with invalid characters, but you've got the idea!
 
 .. seealso::
-    CouchDB Wiki:
-        - `Showing Documents
-          <http://wiki.apache.org/couchdb/Formatting_with_Show_and_List#Showing_Documents>`_
-
     CouchDB Guide:
         - `Show Functions <http://guide.couchdb.org/editions/1/en/show.html>`_
 
@@ -486,10 +482,6 @@ be a string when used inside a list function, so you'll need to use
 returning it.
 
 .. seealso::
-    CouchDB Wiki:
-        - `Listing Views with CouchDB 0.10 and later
-          <http://wiki.apache.org/couchdb/Formatting_with_Show_and_List#Listing_Views_with_CouchDB_0.10_and_later>`_
-
     CouchDB Guide:
         - `Transforming Views with List Functions
           <http://guide.couchdb.org/draft/transforming.html>`_
@@ -540,11 +532,6 @@ A basic example that demonstrates all use-cases of update handlers:
         doc['edited_by'] = req['userCtx']['name']
         return [doc, 'Edited World!']
     }
-
-.. seealso::
-    CouchDB Wiki:
-        - `Document Update Handlers
-          <http://wiki.apache.org/couchdb/Document_Update_Handlers>`_
 
 .. _filterfun:
 
@@ -683,10 +670,6 @@ parameters to the :ref:`changes feed<changes>`::
     CouchDB Guide:
         - `Guide to filter change notification
           <http://guide.couchdb.org/draft/notifications.html#filters>`_
-
-    CouchDB Wiki:
-        - `Filtered replication
-          <http://wiki.apache.org/couchdb/Replication#Filtered_Replication>`_
 
 .. _vdufun:
 
@@ -871,7 +854,3 @@ modified by a user with the ``_admin`` role:
     CouchDB Guide:
         - `Validation Functions
           <http://guide.couchdb.org/editions/1/en/validation.html>`_
-
-    CouchDB Wiki:
-        - `Document Update Validation
-          <http://wiki.apache.org/couchdb/Document_Update_Validation>`_

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -151,10 +151,6 @@ Python and Sphinx are only required for building the online documentation.
 Documentation build can be disabled by adding the ``--disable-docs`` flag to
 the ``configure`` script.
 
-.. seealso::
-
-    * `Installing CouchDB <https://cwiki.apache.org/confluence/display/COUCHDB/Installing+CouchDB>`_
-
 Debian-based Systems
 --------------------
 

--- a/src/replication/protocol.rst
+++ b/src/replication/protocol.rst
@@ -1891,7 +1891,6 @@ Reference
 
 * `Refuge RCouch wiki <https://github.com/refuge/rcouch/wiki/Replication-Algorithm>`_
 * `CouchBase Lite IOS wiki <https://github.com/couchbase/couchbase-lite-ios/wiki/Replication-Algorithm>`_
-* `CouchDB documentation <http://wiki.apache.org/couchdb/Replication>`_
 
 .. _ECMA-262: http://www.ecma-international.org/publications/files/ecma-st/ECMA-262.pdf
 .. _MVCC: http://en.wikipedia.org/wiki/Multiversion_concurrency_control


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Remove broken links to previous CouchDB wiki (wiki.apache.org).

## Testing recommendations
affected docs:
- src/ddocs/ddocs.rst 
- src/install/unix.rst
- src/replication/protocol.rst

## GitHub issue number
Fixes #351 

## Related Pull Requests

## Checklist

- [] Documentation is written and is accurate;
- [X] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
