### PR TITLE
fix: remove trailing whitespace

### DIFF
--- a/src/whatsnew/2.3.rst
+++ b/src/whatsnew/2.3.rst
@@ -82,7 +82,7 @@ Upgrade Notes
         [ssl]
         enable = true
 
-    If the legacy httpsd configuration is found in your ini file, this will 
+    If the legacy httpsd configuration is found in your ini file, this will
     still enable SSL support, so existing configurations do not need to be
     changed.
 


### PR DESCRIPTION
I noticed some errant whitespace was causing `make check` to fail while checking https://github.com/apache/couchdb-documentation/pull/354. This PR removes it.