### PR TITLE
Startup script uses COUCHDB_ARGS_FILE for vm.args path

### DIFF
--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -66,10 +66,10 @@ is the same as setting the ``ERL_FLAGS`` environment variable.
 If there is a need to use different ``vm.args`` or ``sys.config`` files, for
 example, in different locations to the ones provided by CouchDB, or you don't
 want to edit the original files, the default locations may be changed by
-setting the COUCHDB_VM_ARGS_FILE or COUCHDB_SYSCONFIG_FILE environment
-variables::
+setting the COUCHDB_ARGS_FILE or COUCHDB_SYSCONFIG_FILE environment
+variables to an absolute path::
 
-    export COUCHDB_VM_ARGS_FILE="/path/to/my/vm.args"
+    export COUCHDB_ARGS_FILE="/path/to/my/vm.args"
     export COUCHDB_SYSCONFIG_FILE="/path/to/my/sys.config"
 
 Parameter names and values

--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -67,7 +67,7 @@ If there is a need to use different ``vm.args`` or ``sys.config`` files, for
 example, in different locations to the ones provided by CouchDB, or you don't
 want to edit the original files, the default locations may be changed by
 setting the COUCHDB_ARGS_FILE or COUCHDB_SYSCONFIG_FILE environment
-variables to an absolute path::
+variables::
 
     export COUCHDB_ARGS_FILE="/path/to/my/vm.args"
     export COUCHDB_SYSCONFIG_FILE="/path/to/my/sys.config"


### PR DESCRIPTION
This seems to be a discrepancy from the start, see original pull requests:

* https://github.com/apache/couchdb/pull/1095 (code)
* https://github.com/apache/couchdb-documentation/pull/227 (docs)

~~Note also the script seems unhappy with relative paths, so I've also snuck a wording change alongside the main fix here.~~ <ins>I've filed https://github.com/apache/couchdb/issues/1757 instead, and kept this patch focused on the incorrect ENV variable name</ins>