### PR TITLE
Add new return codes for database creation/deletion

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -166,7 +166,8 @@
     :>json string error: Error type. Available if response code is ``4xx``
     :>json string reason: Error description. Available if response code is
       ``4xx``
-    :code 201: Database created successfully
+    :code 201: Database created successfully (quorum is met)
+    :code 202: Accepted (at least by one node)
     :code 400: Invalid database name
     :code 401: CouchDB Server Administrator privileges required
     :code 412: Database already exists
@@ -267,7 +268,8 @@
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
     :>json boolean ok: Operation status
-    :code 200: Database removed successfully
+    :code 200: Database removed successfully (quorum is met and database is deleted by at least one node)
+    :code 202: Accepted (deleted by at least one of the nodes, quorum is not met yet)
     :code 400: Invalid database name or forgotten document id by accident
     :code 401: CouchDB Server Administrator privileges required
     :code 404: Database doesn't exist or invalid database name


### PR DESCRIPTION
## Overview

There is a change in status codes returned by create/delete database operations

* PUT <db>
  - Database creation returns 201 - Creation if the quorum is met
  - Database creation returns 202 - Accepted if at least one node responds ok
  - Database creation returns 500 - Error if there is no correct response from any node
* DELETE <db>
  - Database deletion returns 404 - Not found if all nodes respond not found
  - Database deletion returns 200 - OK if the quorum is met and at least one is ok
  - Database deletion returns 202 - Accepted if the number of responses are bellow quorum and at least one is ok
  - Database deletion returns 500 - Error in other cases

## Testing recommendations

N/A

## GitHub issue number

## Related Pull Requests

- https://github.com/apache/couchdb/pull/1139 (issue https://github.com/apache/couchdb/issues/1136):  Error 500 deleting DB without quorum
- https://github.com/apache/couchdb/pull/1127 (issue https://github.com/apache/couchdb/issues/603):  Error 500 when creating a db below quorum

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
