### PR TITLE
Change type of purge_seq from number to string

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -74,7 +74,9 @@
     :>json string instance_start_time: Always ``"0"``. (Returned for legacy
       reasons.)
     :>json object other: Used by Cloudant. *Deprecated.*
-    :>json number purge_seq: The number of purge operations on the database.
+    :>json string purge_seq: An opaque string that describes the purge state
+      of the database. Do not rely on this string for counting the number
+      of purge operations.
     :>json number sizes.active: The size of live data inside the database, in
       bytes.
     :>json number sizes.external: The uncompressed size of database contents


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Change type of `purge_seq` from number to string.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
jiangphs-mbp-2:couchdb-documentation jiangph$ make check
python ext/linter.py src/
```
## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->
https://github.com/apache/couchdb-documentation/issues/364
## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [X] Documentation is written and is accurate;
- [X] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
