### PR TITLE
Config cluster ref fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ext/*.pyc
 ext/__pycache__/
 build/
+venv
 *~
 *.swp
 *.bak

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ You can view the latest rendered build of this content at:
 Install Python 2.7+ and pip. Then:
 
 ```sh
-$ sudo pip install Sphinx sphinx_rtd_theme
+$ virtualenv venv
+$ . ./venv/bin/activate
+$ pip install -r requirements.txt
 $ make html # builds the docs
 $ make check # syntax checks the docs
 ```

--- a/src/config/cluster.rst
+++ b/src/config/cluster.rst
@@ -40,7 +40,7 @@ Cluster Options
     creation time.
 
     .. seealso::
-        httpdomain:put:`PUT /{db} </{db}>`
+        :http:put:`PUT /{db} </{db}>`
 
     .. config:option:: n
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This fixes the broken reference to the PUT db API

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

`make html` and open `build/html/config/cluster.html` locally to confirm link works

Not sure if this is really passing though?
```
$ make check
python3 ext/linter.py src/
$ echo $?
0
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

FIxes #383 

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
