### PR TITLE
Update configuration of compaction daemon

### DIFF
--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -172,6 +172,17 @@ Configuration of Compaction Daemon
             [compaction_daemon]
             min_file_size = 131072
 
+    .. config:option:: snooze_period_ms
+
+        With lots of databases and/or with lots of design docs in one or more
+        databases, the compaction_daemon can create significant CPU load when
+        checking whether databases and view indexes need compacting. The
+        ``snooze_period_ms`` setting ensures a smoother CPU load. Defaults to
+        3000 milliseconds wait.
+
+            [compaction_daemon]
+            snooze_period_ms = 3000
+
 .. _config/view_compaction:
 
 Views Compaction Options

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -157,7 +157,8 @@ Configuration of Compaction Daemon
     .. config:option:: check_interval
 
         The delay, in seconds, between each check for which database and view
-        indexes need to be compacted::
+        indexes need to be compacted. In other words, this delay will occur
+        after *all* databases and views are compacted (or at least checked)::
 
             [compaction_daemon]
             check_interval = 3600

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -160,7 +160,7 @@ Configuration of Compaction Daemon
         indexes need to be compacted::
 
             [compaction_daemon]
-            check_interval = 300
+            check_interval = 3600
 
     .. config:option:: min_file_size
 


### PR DESCRIPTION
#### Fix default `check_interval` value in compaction docs

Since apache/couchdb@58fef34 "feat: bump the compaction daemon
check_interval to one hour", the default value is `3600`.

---

#### Try to make `check_interval` explanation clearer

We had a hard time finding whether `check_interval` was waited between
*each database compaction*, or between *a whole compaction run for all
databases*.

I propose to make it very explicit.

---

#### Add missing `snooze_period_ms` in compaction docs

This new parameter was introduced in apache/couchdb@e5bf9d4 "add
snooze_period doc to default.ini" and changed in apache/couchdb@5471694
"Add snooze_period_ms for finer tuning".