### PR TITLE
Fix linter sometimes ignoring errors

### DIFF
--- a/ext/linter.py
+++ b/ext/linter.py
@@ -26,7 +26,6 @@ IGNORE_ERROR = False
 def error_report(file, line, msg, _state=[]):
     global HAS_ERRORS, IGNORE_ERROR
     if IGNORE_ERROR:
-        IGNORE_ERROR = False
         return
     if _state and _state[0] == file.name:
         pass
@@ -64,6 +63,8 @@ def iter_rst_files(path):
 
 
 def validate(file):
+    global IGNORE_ERROR
+    IGNORE_ERROR = False
     rules = [rule(file) for rule in RULES]
     for rule in rules:
         for _ in rule:
@@ -103,6 +104,8 @@ def silent_scream(file):
         if counter:
             IGNORE_ERROR = True
             counter -= 1
+        else:
+            IGNORE_ERROR = False
 
         match = re.match("\s*.. lint: ignore errors for the next (\d+) line?", line)
         if match:

--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -24,8 +24,6 @@ Base CouchDB Options
 
 .. config:section:: couchdb :: Base CouchDB Options
 
-    .. lint: ignore errors for the next 1 line
-
     .. config:option:: attachment_stream_buffer_size :: Attachment streaming buffer
 
         Higher values may result in better read performance due to fewer read

--- a/src/cve/2012-5641.rst
+++ b/src/cve/2012-5641.rst
@@ -10,8 +10,6 @@
 .. License for the specific language governing permissions and limitations under
 .. the License.
 
-.. lint: ignore errors for the next 5 lines
-
 .. _cve/2012-5641:
 
 ==================================================================================

--- a/src/cve/2014-2668.rst
+++ b/src/cve/2014-2668.rst
@@ -10,8 +10,6 @@
 .. License for the specific language governing permissions and limitations under
 .. the License.
 
-.. lint: ignore errors for the next 5 lines
-
 .. _cve/2014-2668:
 
 ==================================================================================

--- a/src/intro/curl.rst
+++ b/src/intro/curl.rst
@@ -51,8 +51,6 @@ clarity):
 
         shell> curl 'http://couchdb:5984/_uuids?count=5'
 
-.. lint: ignore errors for the next 15 lines
-
 .. note::
     On Microsoft Windows, use double-quotes anywhere you see single-quotes in
     the following examples. Use doubled double-quotes ("") anywhere you see

--- a/src/replication/intro.rst
+++ b/src/replication/intro.rst
@@ -26,7 +26,6 @@ the end of the process, all active documents on the source database are also in
 the destination database and all documents that were deleted in the source
 databases are also deleted on the destination database (if they even existed).
 
-
 Transient and Persistant Replication
 ====================================
 


### PR DESCRIPTION
Recently I've noticed that sometimes, my local `make check` doesn't show any errors, but Travis does.

I finally traced this down to a logic error in how the "ignore errors for the next _n_ lines" parser worked.  Its `IGNORE_ERROR` flag wasn't being cleared if the "ignore errors for the next _n_ lines" directive was invoked, but no error appeared. Now, we always clear that flag correctly, and forcibly clear it when switching files to be 100% sure.

The problem was a Heisenbug because the directory traversal code can traverse directories in different orders, depending on how the `git clone` operation builds the directory tree. Fun!

Ironically, this bug only surfaced because I relaxed the max line length from 80 to 90 characters, so all of the current ignore directives in our code never actually triggered an error that would be cleared.