### PR TITLE
Mention [couch_httpd_auth] cookie_domain

### DIFF
--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -132,7 +132,7 @@ Authentication Configuration
 
             [couch_httpd_auth]
             allow_persistent_cookies = false
-    
+
     .. config:option:: cookie_domain :: Cookie Domain
 
         .. versionadded:: 2.1.1

--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -132,6 +132,16 @@ Authentication Configuration
 
             [couch_httpd_auth]
             allow_persistent_cookies = false
+    
+    .. config:option:: cookie_domain :: Cookie Domain
+
+        .. versionadded:: 2.1.1
+
+        Configures the ``domain`` attribute of the ``AuthSession`` cookie. By default the
+        ``domain`` attribute is empty, resulting in the cookie being set on CouchDB's domain. ::
+
+            [couch_httpd_auth]
+            cookie_domain = example.com
 
     .. config:option:: auth_cache_size :: Authentication cache
 


### PR DESCRIPTION
## Overview

I discovered the new-ish `cookie_domain` setting kind of by accident. This adds a bit of documentation for it.

## Testing recommendations

Does my writing make sense? Is the `versionadded` note correct?

## Related Pull Requests

https://github.com/apache/couchdb/pull/827

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged