### PR TITLE
Mention [cors] max_age

### DIFF
--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -568,6 +568,14 @@ Cross-Origin Resource Sharing
             [cors]
             methods = GET,POST
 
+    .. config:option:: max_age
+
+        Sets the ``Access-Control-Max-Age`` header in seconds. Use it to
+        avoid repeated ``OPTIONS`` requests.
+
+            [cors]
+            max_age = 3600
+
     .. seealso::
         Original JIRA `implementation ticket <https://issues.apache.org/jira/browse/COUCHDB-431>`_
 


### PR DESCRIPTION
## Overview

The [2.1 release notes](https://docs.couchdb.org/en/latest/whatsnew/2.1.html) mentioned fixing this parameter. I didn't even know it existed, but it's quite helpful to improve replication performance as `OPTIONS` requests can be cached.

## Testing recommendations

Is it correct what I've written?

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged