### PR TITLE
Include note about enabling couch_peruser.

### DIFF
--- a/src/config/couch-peruser.rst
+++ b/src/config/couch-peruser.rst
@@ -33,6 +33,9 @@ couch_peruser Options
 
         [couch_peruser]
         enable = false
+        
+    .. note::
+        The ``_users`` database must exist before couch_peruser can be enabled.
 
     .. config:option:: delete_dbs
 

--- a/src/config/couch-peruser.rst
+++ b/src/config/couch-peruser.rst
@@ -33,7 +33,7 @@ couch_peruser Options
 
         [couch_peruser]
         enable = false
-        
+
     .. note::
         The ``_users`` database must exist before couch_peruser can be enabled.
 


### PR DESCRIPTION
## Overview
There is no indication in the documentation that the existence of the `_users` database is a prerequisite to enabling `couch_peruser`. This note would have saved me quite a bit of time. 

Source of note is here: 
https://github.com/apache/couchdb/issues/749#issuecomment-322057875

## Checklist

- [x] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
