### PR TITLE
updated query servers documentation

### DIFF
--- a/src/api/ddoc/common.rst
+++ b/src/api/ddoc/common.rst
@@ -47,8 +47,7 @@
     Currently it is the following:
 
     * **language** (*string*): Defines :ref:`Query Server <query-server>`
-      :config:section:`key <query_servers>` to process design document
-      functions
+      to process design document functions
     * **options** (*object*): View's default options
     * **filters** (*object*): :ref:`Filter functions <filterfun>` definition
     * **lists** (*object*): :ref:`List functions <listfun>` definition

--- a/src/config/query-servers.rst
+++ b/src/config/query-servers.rst
@@ -21,63 +21,61 @@ Query Servers
 Query Servers Definition
 ========================
 
-.. config:section:: query_servers :: Query Servers Definition
+.. versionchanged:: 2.3 Changed configuration method for Query Servers
+  and Native Query Servers.
 
-    .. versionchanged:: 2.3 Changed configuration method for Query Servers
-      and Native Query Servers.
+CouchDB delegates computation of :ref:`design documents <ddocs>` functions
+to external query servers. The external query server is a special OS
+process which communicates with CouchDB over standard input/output using a
+very simple line-based protocol with JSON messages.
 
-    CouchDB delegates computation of :ref:`design documents <ddocs>` functions
-    to external query servers. The external query server is a special OS
-    process which communicates with CouchDB over standard input/output using a
-    very simple line-based protocol with JSON messages.
+An external query server may be defined with environment variables following
+this pattern::
 
-    An external query server may be defined with environment variables following
-    this pattern::
+    COUCHDB_QUERY_SERVER_LANGUAGE="PATH ARGS"
 
-        COUCHDB_QUERY_SERVER_LANGUAGE="PATH ARGS"
+Where:
 
-    Where:
+- ``LANGUAGE``: is a programming language which code this query server may
+  execute. For instance, there are `PYTHON`, `RUBY`, `CLOJURE` and other
+  query servers in the wild. This value in *lowercase* is also used for `ddoc`
+  field ``language`` to determine which query server processes the functions.
 
-    - ``LANGUAGE``: is a programming language which code this query server may
-      execute. For instance, there are `PYTHON`, `RUBY`, `CLOJURE` and other
-      query servers in the wild. This value in *lowercase* is also used for `ddoc`
-      field ``language`` to determine which query server processes the functions.
+  Note, that you may set up multiple query servers for the same programming
+  language, but you have to name them differently (like `PYTHONDEV` etc.).
 
-      Note, that you may set up multiple query servers for the same programming
-      language, but you have to name them differently (like `PYTHONDEV` etc.).
+- ``PATH``: is a system path to the executable binary program that runs the
+  query server.
 
-    - ``PATH``: is a system path to the executable binary program that runs the
-      query server.
+- ``ARGS``: optionally, you may specify additional command line arguments
+  for the executable ``PATH``.
 
-    - ``ARGS``: optionally, you may specify additional command line arguments
-      for the executable ``PATH``.
+The default query server is written in :ref:`JavaScript <query-server/js>`,
+running via `Mozilla SpiderMonkey`_. It requires no special environment
+settings to enable, but is the equivalent of these two variables::
 
-    The default query server is written in :ref:`JavaScript <query-server/js>`,
-    running via `Mozilla SpiderMonkey`_. It requires no special environment
-    settings to enable, but is the equivalent of these two variables::
+    COUCHDB_QUERY_SERVER_JAVASCRIPT="/opt/couchdb/bin/couchjs /opt/couchdb/share/server/main.js"
+    COUCHDB_QUERY_SERVER_COFFEESCRIPT="/opt/couchdb/bin/couchjs /opt/couchdb/share/server/main-coffee.js"
 
-        COUCHDB_QUERY_SERVER_JAVASCRIPT="/opt/couchdb/bin/couchjs /opt/couchdb/share/server/main.js"
-        COUCHDB_QUERY_SERVER_COFFEESCRIPT="/opt/couchdb/bin/couchjs /opt/couchdb/share/server/main-coffee.js"
+By default, ``couchjs`` limits the max runtime allocation to 64MiB.
+If you run into out of memory issue in your ddoc functions,
+you can adjust the memory limitation (here, increasing to 512 MiB)::
 
-    By default, ``couchjs`` limits the max runtime allocation to 64MiB.
-    If you run into out of memory issue in your ddoc functions,
-    you can adjust the memory limitation (here, increasing to 512 MiB)::
+    COUCHDB_QUERY_SERVER_JAVASCRIPT="/usr/bin/couchjs -S 536870912 /usr/share/server/main.js"
 
-        COUCHDB_QUERY_SERVER_JAVASCRIPT="/usr/bin/couchjs -S 536870912 /usr/share/server/main.js"
+For more info about the available options, please consult ``couchjs -h``.
 
-    For more info about the available options, please consult ``couchjs -h``.
+.. _Mozilla SpiderMonkey: https://developer.mozilla.org/en/docs/SpiderMonkey
 
-    .. _Mozilla SpiderMonkey: https://developer.mozilla.org/en/docs/SpiderMonkey
+.. seealso::
+    The :ref:`Mango Query Server <api/db/_find>` is a declarative language
+    that requires *no programming*, allowing for easier indexing and finding
+    of data in documents.
 
-    .. seealso::
-        The :ref:`Mango Query Server <api/db/_find>` is a declarative language
-        that requires *no programming*, allowing for easier indexing and finding
-        of data in documents.
-
-        The :ref:`Native Erlang Query Server <config/native_query_servers>`
-        allows running `ddocs` written in Erlang natively, bypassing
-        stdio communication and JSON serialization/deserialization round trip
-        overhead.
+    The :ref:`Native Erlang Query Server <config/native_query_servers>`
+    allows running `ddocs` written in Erlang natively, bypassing
+    stdio communication and JSON serialization/deserialization round trip
+    overhead.
 
 .. _config/query_server_config:
 

--- a/src/query-server/index.rst
+++ b/src/query-server/index.rst
@@ -23,10 +23,10 @@ protocol through stdio interface and processed all
 
 The default query server is written in
 :ref:`JavaScript <query-server/js>`, running via `Mozilla SpiderMonkey`_.
-You can use other languages by setting a Query server key in the ``language``
-property of a design document or the `Content-Type` header of a
-`temporary view`. Design documents that do not specify a ``language`` property
-are assumed to be of type `javascript`.
+You can use :ref:`other languages <config/query_servers>` by setting a Query
+server key in the ``language`` property of a design document or the
+`Content-Type` header of a `temporary view`. Design documents that do not
+specify a ``language`` property are assumed to be of type `javascript`.
 
 .. _Mozilla SpiderMonkey: https://developer.mozilla.org/en/docs/SpiderMonkey
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This PR supplement query servers documentation so it is now more clear that since 2.3 environment variables only should be used.

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
