### PR TITLE
Clarify how design documents are created

### DIFF
--- a/src/ddocs/ddocs.rst
+++ b/src/ddocs/ddocs.rst
@@ -32,6 +32,19 @@ them extensively within each function:
 - :ref:`Database Security object <security_object>`
 - :ref:`Guide to JavaScript Query Server <query-server/js>`
 
+Creation
+========
+
+Design documents are denoted by an id field with the format ``_design/{name}``.
+
+**Example**:
+
+.. code-block:: json
+
+    {
+        "id": "_design/example",
+    }
+
 .. _viewfun:
 
 View Functions


### PR DESCRIPTION
## Overview

Currently, there is no documentation on what denotes a design document in its documentation page. This pull request adds a brief "Creation" section to the documentation, explaining the concept of ```{"id": "_design/{name}"}```

## Testing recommendations

This is a simple documentation addition. No additional testing steps should be necessary

## GitHub issue number

N/A

## Related Pull Requests

N/A

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
