### PR TITLE
Correct "Refuse building with known bad versions of Erlang" issue number

### DIFF
--- a/src/whatsnew/2.3.rst
+++ b/src/whatsnew/2.3.rst
@@ -107,7 +107,7 @@ Upgrade Notes
 * :ghissue:`1680`: The embedded version of ``rebar`` used to build CouchDB has been
   updated to the last version of ``rebar2`` available. This assists in building on
   non-x86 platforms.
-* :ghissue:`1875`: Refuse building with known bad versions of Erlang.
+* :ghissue:`1857`: Refuse building with known bad versions of Erlang.
 
 .. _release/2.3.1:
 
@@ -121,7 +121,7 @@ Features
 
 * :ghissue:`1811`: Add new ``/{db}/_sync_shards`` endpoint (admin-only).
 * :ghissue:`1870`: Update to mochiweb 2.19.0. See also :ghissue:`1875`.
-* :ghissue:`1875`: Refuse building with known bad versions of Erlang.
+* :ghissue:`1857`: Refuse building with known bad versions of Erlang.
 * :ghissue:`1880`: Compaction: Add snooze_period_ms for finer tuning.
 
 Bugfixes


### PR DESCRIPTION
## Overview

The docs list a bugfix "Refuse building with known bad versions of Erlang" and incorrectly reference it as issue 1875, when it's actually issue 1857.
