### PR TITLE
Update local replication documentation

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -608,15 +608,13 @@
     :<json string filter: The name of a :ref:`filter function <filterfun>`.
     :<json string proxy: Address of a proxy server through which replication
       should occur (protocol can be "http" or "socks5")
-    :<json string/object source: Source database name or URL or an object
-      which contains the full URL of the source database with additional
-      parameters like headers. Eg: 'source_db_name' or
-      'http://example.com/source_db_name' or
+    :<json string/object source: Fully qualified source database URL or an
+      object which contains the full URL of the source database with additional
+      parameters like headers. Eg: 'http://example.com/source_db_name' or
       {"url":"url in here", "headers": {"header1":"value1", ...}}
-    :<json string/object target: Target database name or URL or an object
-      which contains the full URL of the target database with additional
-      parameters like headers. Eg: 'target_db_name' or
-      'http://example.com/target_db_name' or
+    :<json string/object target: Fully qualified target database URL or an
+      object which contains the full URL of the target database with additional
+      parameters like headers. Eg: 'http://example.com/target_db_name' or
       {"url":"url in here", "headers": {"header1":"value1", ...}}
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
@@ -660,13 +658,13 @@
 
         POST /_replicate HTTP/1.1
         Accept: application/json
-        Content-Length: 36
+        Content-Length: 80
         Content-Type: application/json
         Host: localhost:5984
 
         {
-            "source": "db_a",
-            "target": "db_b"
+            "source": "http://127.0.0.1:5984/db_a",
+            "target": "http://127.0.0.1:5984/db_b"
         }
 
     **Response**

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -652,6 +652,10 @@
     :json string start_time:  Date/Time replication operation started in
       :rfc:`2822` format
 
+.. note::
+    As of CouchDB 2.0.0, fully qualified URLs are required for both the
+    replication `source` and `target` parameters.
+
     **Request**
 
     .. code-block:: http

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -611,11 +611,19 @@
     :<json string/object source: Fully qualified source database URL or an
       object which contains the full URL of the source database with additional
       parameters like headers. Eg: 'http://example.com/source_db_name' or
-      {"url":"url in here", "headers": {"header1":"value1", ...}}
+      {"url":"url in here", "headers": {"header1":"value1", ...}} . For
+      backwards compatibility, CouchDB 3.x will auto-convert bare database
+      names by prepending the address and port CouchDB is listening on, to
+      form a complete URL. This behaviour is deprecated in 3.x and will be
+      removed in CouchDB 4.0.
     :<json string/object target: Fully qualified target database URL or an
       object which contains the full URL of the target database with additional
       parameters like headers. Eg: 'http://example.com/target_db_name' or
-      {"url":"url in here", "headers": {"header1":"value1", ...}}
+      {"url":"url in here", "headers": {"header1":"value1", ...}} . For
+      backwards compatibility, CouchDB 3.x will auto-convert bare database
+      names by prepending the address and port CouchDB is listening on, to
+      form a complete URL. This behaviour is deprecated in 3.x and will be
+      removed in CouchDB 4.0.
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
     :>json array history: Replication history (see below)

--- a/src/intro/api.rst
+++ b/src/intro/api.rst
@@ -605,7 +605,7 @@ easy to make)::
 Now we can use the database `albums-replica` as a replication target::
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
-         -d '{"source":"albums","target":"albums-replica"}' \
+         -d '{"source":"http://127.0.0.1:5984/albums","target":"http://127.0.0.1:5984/albums-replica"}' \
          -H "Content-Type: application/json"
 
 .. note::
@@ -664,7 +664,7 @@ HTML) and so far we've seen links relative to the server we're working on
 (hence local). You can also specify a remote database as the target::
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
-         -d '{"source":"albums","target":"http://example.org:5984/albums-replica"}' \
+         -d '{"source":"http://127.0.0.1:5984/albums","target":"http://example.org:5984/albums-replica"}' \
          -H "Content-Type:application/json"
 
 Using a *local source* and a *remote target* database is called *push
@@ -683,7 +683,7 @@ replication*. This is great for getting the latest changes from a server that
 is used by others::
 
     curl -vX POST http://127.0.0.1:5984/_replicate \
-         -d '{"source":"http://example.org:5984/albums-replica","target":"albums"}' \
+         -d '{"source":"http://example.org:5984/albums-replica","target":"http://127.0.0.1:5984/albums"}' \
          -H "Content-Type:application/json"
 
 Finally, you can run remote replication, which is mostly useful for management

--- a/src/intro/api.rst
+++ b/src/intro/api.rst
@@ -609,6 +609,10 @@ Now we can use the database `albums-replica` as a replication target::
          -H "Content-Type: application/json"
 
 .. note::
+    As of CouchDB 2.0.0, fully qualified URLs are required for both the
+    replication `source` and `target` parameters.
+
+.. note::
     CouchDB supports the option ``"create_target":true`` placed in the JSON
     POSTed to the :ref:`_replicate <api/server/replicate>` URL. It implicitly
     creates the target database if it doesn't exist.


### PR DESCRIPTION
Followup from [this slack conversation](https://couchdb.slack.com/archives/C49LEE7NW/p1562409911483700) with @janl, to update the replication documentation for the new post-2.x requirement for full URLs in replication source and target.