### PR TITLE
Clarify what the allow_persistent_cookies config value does

### DIFF
--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -128,7 +128,8 @@ Authentication Configuration
 
     .. config:option:: allow_persistent_cookies :: Persistent cookies
 
-        Makes cookies persistent if ``true``. ::
+        When set to ``true``, CouchDB will refresh the session cookie whenever
+        the session is nearing expiration. ::
 
             [couch_httpd_auth]
             allow_persistent_cookies = false


### PR DESCRIPTION
This is a very over-due followup to https://github.com/apache/couchdb/issues/1598#issuecomment-419463294