### PR TITLE
Improve UNIX binary package install instructions

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -26,20 +26,19 @@ to install CouchDB is to use the convenience binary packages:
 
 * CentOS/RHEL 6
 * CentOS/RHEL 7
-* Debian 8 (jessie)
 * Debian 9 (stretch)
-* Ubuntu 14.04 (trusty)
+* Debian 10 (buster)
 * Ubuntu 16.04 (xenial)
 * Ubuntu 18.04 (bionic)
 
-The RedHat-style rpm packages and Debian-style deb packages will install
-CouchDB at ``/opt/couchdb`` and ensure CouchDB is run at system startup by the
-appropriate init subsystem (SysV-style initd, upstart, systemd).
+These RedHat-style rpm packages and Debian-style deb packages will install CouchDB at
+``/opt/couchdb`` and ensure CouchDB is run at system startup by the appropriate init
+subsystem (SysV-style initd or systemd).
 
-The Debian-style deb packages *also* pre-configure CouchDB as a standalone or
-clustered node, prompt for the address to which it will bind, and a password
-for the admin user. Responses to these prompts may be pre-seeded using standard
-debconf tools. Further details are in the `README.Debian`_ file.
+The Debian-style deb packages *also* pre-configure CouchDB as a standalone or clustered
+node, prompt for the address to which it will bind, and a password for the admin user.
+Responses to these prompts may be pre-seeded using standard ``debconf`` tools. Further
+details are in the `README.Debian`_ file.
 
 .. _README.Debian: https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
 
@@ -49,6 +48,30 @@ disappear or become unreliable.
 
 Enabling the Apache CouchDB package repository
 ----------------------------------------------
+
+.. highlight:: sh
+
+**Debian 9 (stretch)**: Run the following commands::
+
+    $ apt install -y --no-install-recommends apt-transport-https
+    $ echo "deb https://apache.bintray.com/couchdb-deb stretch main" \
+        | sudo tee -a /etc/apt/sources.list.d/couchdb.list
+
+**Debian 10 (buster)**: Run the following commands::
+
+    $ echo "deb https://apache.bintray.com/couchdb-deb buster main" \
+        | sudo tee -a /etc/apt/sources.list.d/couchdb.list
+
+**Ubuntu 16.04 (Xenial)**: Run the following commands::
+
+    $ apt install -y --no-install-recommends apt-transport-https
+    $ echo "deb https://apache.bintray.com/couchdb-deb xenial main" \
+        | sudo tee -a /etc/apt/sources.list.d/couchdb.list
+
+**Ubuntu 18.04 (Bionic)**: Run the following commands::
+
+    $ echo "deb https://apache.bintray.com/couchdb-deb bionic main" \
+        | sudo tee -a /etc/apt/sources.list.d/couchdb.list
 
 .. highlight:: ini
 
@@ -61,7 +84,16 @@ Enabling the Apache CouchDB package repository
     repo_gpgcheck=0
     enabled=1
 
-**RedHat/RHEL**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``. Be sure to replace the ``7`` below with ``6`` if you are on a EL6 distribution::
+**RedHat 6**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
+
+    [bintray--apache-couchdb-rpm]
+    name=bintray--apache-couchdb-rpm
+    baseurl=http://apache.bintray.com/couchdb-rpm/el6/$basearch/
+    gpgcheck=0
+    repo_gpgcheck=0
+    enabled=1
+
+**RedHat 7**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
 
     [bintray--apache-couchdb-rpm]
     name=bintray--apache-couchdb-rpm
@@ -70,47 +102,32 @@ Enabling the Apache CouchDB package repository
     repo_gpgcheck=0
     enabled=1
 
-.. highlight:: sh
-
-**Debian/Ubuntu**: Run the command::
-
-    $ echo "deb https://apache.bintray.com/couchdb-deb {distribution} main" \
-        | sudo tee -a /etc/apt/sources.list
-
-and replace ``{distribution}`` with the appropriate choice for your OS
-version:
-
-* Debian 8: ``jessie``
-* Debian 9: ``stretch``
-* Ubuntu 14.04: ``trusty``
-* Ubuntu 16.04: ``xenial``
-* Ubuntu 18.04: ``bionic``
-
 Installing the Apache CouchDB packages
 --------------------------------------
 
 .. highlight:: sh
 
-**RedHat/CentOS**: Run the command::
+**Debian/Ubuntu**: First, install the CouchDB repository key::
 
-    $ sudo yum -y install epel-release && yum install couchdb
-
-**Your installation is not complete. Be sure to complete the**
-:ref:`Setup <setup>` **steps for a single node or clustered installation.**
-
-**Debian/Ubuntu**: First, install the repository key::
-
+    $ sudo apt install -y curl
     $ curl -L https://couchdb.apache.org/repo/bintray-pubkey.asc \
         | sudo apt-key add -
 
 Then update the repository cache and install the package::
 
-    $ sudo apt-get update && sudo apt-get install couchdb
+    $ sudo apt update && sudo apt install -y couchdb
 
-Debian/Ubuntu installs from binaries will be pre-configured for single node or
+Debian/Ubuntu installs from binaries can be pre-configured for single node or
 clustered installations. For clusters, multiple nodes will still need to be
 joined together and configured consistently across all machines; **follow the**
 :ref:`Cluster Setup <setup/cluster>` **walkthrough** to complete the process.
+
+**RedHat/CentOS**: Run the command::
+
+    $ sudo yum -y install epel-release && sudo yum -y install couchdb
+
+**Your installation is not complete. Be sure to complete the**
+:ref:`Setup <setup>` **steps for a single node or clustered installation.**
 
 Relax! CouchDB is installed and running.
 


### PR DESCRIPTION
## Overview

Every now and then someone hops into IRC, Slack or the mailing lists, who can't figure out how to install CouchDB from package correctly. Usually it's because they pasted without reading and substituting their platform correctly.

This makes the instructions overly explicit.

Oh, and this drops newly deprecated platforms and adds Debian 10 (buster) as supported.

## Testing recommendations

Read it!

## GitHub issue number

n/a

## Related Pull Requests

https://github.com/apache/couchdb-pkg/pull/49
https://github.com/apache/couchdb-pkg/pull/49

## Checklist

- [X] Documentation is written and is accurate;
- [X] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
