### PR TITLE
Remove mention of old size fields

### DIFF
--- a/src/api/database/common.rst
+++ b/src/api/database/common.rst
@@ -66,14 +66,11 @@
     :>json string db_name: The name of the database.
     :>json number disk_format_version: The version of the physical format used
       for the data when it is stored on disk.
-    :>json number data_size: *Deprecated.* Use ``sizes.active`` instead.
-    :>json number disk_size: *Deprecated.* Use ``sizes.file`` instead.
     :>json number doc_count: A count of the documents in the specified
       database.
     :>json number doc_del_count: Number of deleted documents
     :>json string instance_start_time: Always ``"0"``. (Returned for legacy
       reasons.)
-    :>json object other: Used by Cloudant. *Deprecated.*
     :>json string purge_seq: An opaque string that describes the purge state
       of the database. Do not rely on this string for counting the number
       of purge operations.
@@ -118,16 +115,11 @@
                 "w": 2
             },
             "compact_running": false,
-            "data_size": 65031503,
             "db_name": "receipts",
             "disk_format_version": 6,
-            "disk_size": 137433211,
             "doc_count": 6146,
             "doc_del_count": 64637,
             "instance_start_time": "0",
-            "other": {
-                "data_size": 66982448
-            },
             "props": {},
             "purge_seq": 0,
             "sizes": {

--- a/src/api/ddoc/common.rst
+++ b/src/api/ddoc/common.rst
@@ -178,11 +178,14 @@
             "name": "recipe",
             "view_index": {
                 "compact_running": false,
-                "data_size": 926691,
-                "disk_size": 1982704,
                 "language": "python",
                 "purge_seq": 0,
                 "signature": "a59a1bb13fdf8a8a584bc477919c97ac",
+                "sizes": {
+                  "active": 926691,
+                  "disk": 1982704,
+                  "external": 1535701
+                },
                 "update_seq": 12397,
                 "updater_running": false,
                 "waiting_clients": 0,
@@ -200,8 +203,9 @@ The response from :get:`/{db}/_design/{ddoc}/_info` contains
 
 * **compact_running** (*boolean*):  Indicates whether a compaction routine
   is currently running on the view
-* **data_size** (*number*): Actual size in bytes of the view
-* **disk_size** (*number*): Size in bytes of the view as stored on disk
+* **sizes.active** (*number*): The size of live data inside the view, in bytes
+* **sizes.external** (*number*): The uncompressed size of view contents in bytes
+* **sizes.file** (*number*): Size in bytes of the view as stored on disk
 * **language** (*string*): Language for the defined views
 * **purge_seq** (*number*): The purge sequence that has been processed
 * **signature** (*string*): MD5 signature of the views for the design document

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -278,14 +278,9 @@
                 "active": 1162451555
               },
               "purge_seq": 0,
-              "other": {
-                "data_size": 1713103872
-              },
               "doc_del_count": 0,
               "doc_count": 52224,
-              "disk_size": 1178613587,
               "disk_format_version": 6,
-              "data_size": 1162451555,
               "compact_running": false,
               "cluster": {
                 "q": 8,
@@ -307,14 +302,9 @@
                 "active": 67475
               },
               "purge_seq": 0,
-              "other": {
-                "data_size": 2339
-              },
               "doc_del_count": 0,
               "doc_count": 11,
-              "disk_size": 3872387,
               "disk_format_version": 6,
-              "data_size": 67475,
               "compact_running": false,
               "cluster": {
                 "q": 8,

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -67,9 +67,9 @@ Compaction Daemon Rules
 
       .. code-block:: none
 
-          (file_size - data_size) / file_size * 100
+          (sizes.disk - sizes.active) / sizes.disk * 100
 
-      The data_size and file_size values can be obtained when
+      The sizes.active and sizes.disk values can be obtained when
       querying :http:get:`/{db}`.
 
     - ``view_fragmentation``: If the ratio of legacy data, including metadata,
@@ -80,9 +80,9 @@ Compaction Daemon Rules
 
       .. code-block:: none
 
-          (file_size - data_size) / file_size * 100
+          (sizes.disk - sizes.active) / sizes.disk * 100
 
-      The data_size and file_size values can be obtained when querying a
+      The sizes.active and sizes.disk values can be obtained when querying a
       :ref:`view group's information URI <api/ddoc/info>`.
 
     - ``from`` and ``to``: The period for which a database (and its view group)

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -554,8 +554,8 @@ write normal documents::
 .. code-block:: javascript
 
     {"db_name":"mydatabase","doc_count":1,"doc_del_count":0,"update_seq":3,"purge_seq":0,
-    "compact_running":false,"disk_size":12376,"data_size":272,"instance_start_time":"0",
-    "disk_format_version":6,"committed_update_seq":3}
+    "compact_running":false,"sizes":{"active":272,"disk":12376,"external":350},
+    "instance_start_time":"0","disk_format_version":6,"committed_update_seq":3}
 
 If Jan attempted to create a design doc, however, CouchDB would return a
 401 Unauthorized error because the username "jan" is not in the list of

--- a/src/json-structure.rst
+++ b/src/json-structure.rst
@@ -397,14 +397,17 @@ Request object
         "info": {
             "committed_update_seq": 2701412,
             "compact_running": false,
-            "data_size": 7580843252,
             "db_name": "mailbox",
             "disk_format_version": 6,
-            "disk_size": 14325313673,
             "doc_count": 2262757,
             "doc_del_count": 560,
             "instance_start_time": "1347601025628957",
             "purge_seq": 0,
+            "sizes": {
+              "active": 7580843252,
+              "disk": 14325313673,
+              "external": 7803423459
+            },
             "update_seq": 2701412
         },
         "method": "GET",

--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -97,14 +97,17 @@ information about it via :ref:`database information resource <api/db>`::
     {
         "committed_update_seq": 76215,
         "compact_running": true,
-        "data_size": 3787996,
         "db_name": "my_db",
         "disk_format_version": 6,
-        "disk_size": 17703025,
         "doc_count": 5091,
         "doc_del_count": 0,
         "instance_start_time": "0",
         "purge_seq": 0,
+        "sizes": {
+          "active": 3787996,
+          "disk": 17703025,
+          "external": 4763321
+        },
         "update_seq": 76215
     }
 

--- a/src/partitioned-dbs/index.rst
+++ b/src/partitioned-dbs/index.rst
@@ -155,16 +155,11 @@ information:
         "w": 2
       },
       "compact_running": false,
-      "data_size": 0,
       "db_name": "my_new_db",
       "disk_format_version": 7,
-      "disk_size": 66784,
       "doc_count": 0,
       "doc_del_count": 0,
       "instance_start_time": "0",
-      "other": {
-        "data_size": 0
-      },
       "props": {
         "partitioned": true
       },

--- a/src/query-server/protocol.rst
+++ b/src/query-server/protocol.rst
@@ -358,8 +358,11 @@ Couchdb sends::
                     "update_seq": 105,
                     "purge_seq": 0,
                     "compact_running": false,
-                    "disk_size": 15818856,
-                    "data_size": 1535048,
+                    "sizes": {
+                      "active": 1535048,
+                      "disk": 15818856,
+                      "external": 15515850
+                    },
                     "instance_start_time": "1359952188595857",
                     "disk_format_version": 6,
                     "committed_update_seq": 105
@@ -606,8 +609,11 @@ CouchDB sends::
                     "update_seq": 16,
                     "purge_seq": 0,
                     "compact_running": false,
-                    "disk_size": 8044648,
-                    "data_size": 7979601,
+                    "sizes": {
+                      "active": 7979745,
+                      "disk": 8056936,
+                      "external": 8024930
+                    },
                     "instance_start_time": "1374612186131612",
                     "disk_format_version": 6,
                     "committed_update_seq": 16
@@ -731,8 +737,11 @@ CouchDB sends::
                     "update_seq": 19,
                     "purge_seq": 0,
                     "compact_running": false,
-                    "disk_size": 8056936,
-                    "data_size": 7979745,
+                    "sizes": {
+                      "active": 7979745,
+                      "disk": 8056936,
+                      "external": 8024930
+                    },
                     "instance_start_time": "1374612186131612",
                     "disk_format_version": 6,
                     "committed_update_seq": 19

--- a/src/replication/protocol.rst
+++ b/src/replication/protocol.rst
@@ -397,14 +397,17 @@ Get Source Information
         {
             "committed_update_seq": 61772,
             "compact_running": false,
-            "data_size": 70781613961,
             "db_name": "source",
             "disk_format_version": 6,
-            "disk_size": 79132913799,
             "doc_count": 41961,
             "doc_del_count": 3807,
             "instance_start_time": "0",
             "purge_seq": 0,
+            "sizes": {
+              "active": 70781613961,
+              "disk": 79132913799,
+              "external": 72345632950
+            },
             "update_seq": 61772
         }
 
@@ -434,14 +437,15 @@ Get Target Information
             "compact_running": false,
             "db_name": "target",
             "disk_format_version": 5,
-            "disk_size": 77001455,
             "doc_count": 1832,
             "doc_del_count": 1,
             "instance_start_time": "0",
-            "other": {
-                "data_size": 50829452
-            },
             "purge_seq": 0,
+            "sizes": {
+              "active": 50829452,
+              "disk": 77001455,
+              "external": 60326450
+            },
             "update_seq": "1841-g1AAAADveJzLYWBgYMlgTmGQT0lKzi9KdUhJMtbLSs1LLUst0k"
         }
 


### PR DESCRIPTION
## Overview

We replaced the `disk_size` and `data_size` fields with the `sizes` object. This updates the documentation to remove all mention of those deprecated fields in preparation for their removal in 3.0.

## GitHub issue number

apache/couchdb#2162

## Related Pull Requests

apache/couchdb#2163

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
