### PR TITLE
Correct misleading commentary on ERL_MAX_PORTS

### DIFF
--- a/src/install/troubleshooting.rst
+++ b/src/install/troubleshooting.rst
@@ -201,9 +201,10 @@ but the short answer is that you should decrease ``ulimit -n`` or define
 
 erlang stack trace contains ``system_limit``, ``open_port``
 -----------------------------------------------------------
-Erlang has a default limit of 1024 ports, where each FD, tcp connection, and
-linked-in driver uses one port. You seem to have exceeded this. You can
-change it at runtime using the ``ERL_MAX_PORTS`` env variable.
+Erlang has a default limit of 1024 Erlang ports, where some internal
+components uses one Erlang port (the ICU driver, Javascript
+evaluation). You seem to have exceeded this. You can change it at
+runtime using the ``ERL_MAX_PORTS`` env variable.
 
 function raised exception (Cannot encode 'undefined' value as JSON)
 -------------------------------------------------------------------

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -99,13 +99,6 @@ will be continuously replicating.
 Erlang
 ------
 
-Even if you've increased the maximum connections CouchDB will allow,
-the Erlang runtime system will not allow more than 1024 connections by
-default. Adding the following directive to ``(prefix)/etc/default/couchdb`` (or
-equivalent) will increase this limit (in this case to 4096)::
-
-    export ERL_MAX_PORTS=4096
-
 CouchDB versions up to 1.1.x also create Erlang Term Storage (`ETS`_) tables for
 each replication. If you are using a version of CouchDB older than 1.2 and
 must support many replications, also set the ``ERL_MAX_ETS_TABLES`` variable.


### PR DESCRIPTION
ERL_MAX_PORTS affects the number of Erlang ports allowed at once, and
defaults to 1024. An Erlang port is created via erlang:open_port and
is used to launch an executable like couchjs. It is not, directly, a
limit on TCP sockets or file descriptors.
