### PR TITLE
Revert "Correct misleading commentary on ERL_MAX_PORTS"

### DIFF
--- a/src/install/troubleshooting.rst
+++ b/src/install/troubleshooting.rst
@@ -201,10 +201,9 @@ but the short answer is that you should decrease ``ulimit -n`` or define
 
 erlang stack trace contains ``system_limit``, ``open_port``
 -----------------------------------------------------------
-Erlang has a default limit of 1024 Erlang ports, where some internal
-components uses one Erlang port (the ICU driver, Javascript
-evaluation). You seem to have exceeded this. You can change it at
-runtime using the ``ERL_MAX_PORTS`` env variable.
+Erlang has a default limit of 1024 ports, where each FD, tcp connection, and
+linked-in driver uses one port. You seem to have exceeded this. You can
+change it at runtime using the ``ERL_MAX_PORTS`` env variable.
 
 function raised exception (Cannot encode 'undefined' value as JSON)
 -------------------------------------------------------------------

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -99,6 +99,13 @@ will be continuously replicating.
 Erlang
 ------
 
+Even if you've increased the maximum connections CouchDB will allow,
+the Erlang runtime system will not allow more than 1024 connections by
+default. Adding the following directive to ``(prefix)/etc/default/couchdb`` (or
+equivalent) will increase this limit (in this case to 4096)::
+
+    export ERL_MAX_PORTS=4096
+
 CouchDB versions up to 1.1.x also create Erlang Term Storage (`ETS`_) tables for
 each replication. If you are using a version of CouchDB older than 1.2 and
 must support many replications, also set the ``ERL_MAX_ETS_TABLES`` variable.


### PR DESCRIPTION
This reverts commit f6b5f742f0f6d337b2c9895b3f42d8b05533a695.

I was wrong.
