### PR TITLE
Fix typo

### DIFF
--- a/src/best-practices/documents.rst
+++ b/src/best-practices/documents.rst
@@ -32,7 +32,7 @@ a few reasons:
   stored under duplicate ``_id``\ s. This could easily happen with intermediary
   proxies and cache systems that may not inform developers that the failed
   transaction is being retried.
-- ``_id``\ s are are the only unique enforced value within CouchDB so you might
+- ``_id``\ s are the only unique enforced value within CouchDB so you might
   as well make use of this. CouchDB stores its documents in a B+ tree. Each
   additional or updated document is stored as a leaf node, and may require
   re-writing intermediary and parent nodes. You may be able to take advantage of

--- a/src/best-practices/documents.rst
+++ b/src/best-practices/documents.rst
@@ -29,7 +29,7 @@ a few reasons:
 
 - If for any reason you miss the ``200 OK`` reply from CouchDB, and storing the
   document is attempted again, you would end up with the same document content
-  stored under duplicate ``_id``\ s. This could easily happen with intermediary
+  stored under multiple ``_id``\ s. This could easily happen with intermediary
   proxies and cache systems that may not inform developers that the failed
   transaction is being retried.
 - ``_id``\ s are the only unique enforced value within CouchDB so you might


### PR DESCRIPTION
## Overview

Simple typo fix, remove duplicate of the word _"are"_.
