### PR TITLE
Added some missing status codes

### DIFF
--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -27,6 +27,10 @@
     data.
 
     :param db: Database name
+    :<header Content-Type: :mimetype:`application/json`
+    :>header Content-Type: - :mimetype:`application/json`
+    :code 200: Request completed successfully
+    :code 404: Requested database not found
 
     **Request**:
 
@@ -104,6 +108,7 @@
       *Optional*
     :>header Content-Type: - :mimetype:`application/json`
     :code 200: Request completed successfully
+    :code 404: Requested database not found
 
     **Request**:
 

--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -213,6 +213,7 @@
       that this is not the number of rows returned in the actual query.
     :>json number update_seq: Current update sequence for the database
     :code 200: Request completed successfully
+    :code 404: Requested database not found
 
     **Request**:
 

--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -644,6 +644,7 @@ Sending multiple queries to a database
     :>jsonarr string reason: Error reason. *Optional*
     :code 201: Document(s) have been created or updated
     :code 400: The request provided invalid JSON data
+    :code 404: Requested database not found
 
     **Request**:
 

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -111,7 +111,7 @@ Installing the Apache CouchDB packages
 
 **Debian/Ubuntu**: First, install the CouchDB repository key::
 
-    $ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
+    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
       8756C4F765C9AC3CB6B85D62379CE192D401AB61
 
 Then update the repository cache and install the package::


### PR DESCRIPTION
Added the following status codes in the documentation where they were missing:
* `{db}/_find` - 404
* `{db}/_bulk_docs` 404
* `{db}/_all_docs` `GET` 200, 404
* `{db}/_all_docs` `POST` 404
* `{db}/_design_docs` `GET` 404