### PR TITLE
Add autoupdate field to design docs API

### DIFF
--- a/src/api/ddoc/common.rst
+++ b/src/api/ddoc/common.rst
@@ -57,6 +57,8 @@
     * **validate_doc_update** (*string*): :ref:`Validate document update
       <vdufun>` function source
     * **views** (*object*): :ref:`View functions <viewfun>` definition.
+    * **autoupdate** (*boolean*): Indicates whether to automatically build
+      indexes defined in this design document. Default is `true`.
 
     Note, that for ``filters``, ``lists``, ``shows`` and ``updates`` fields
     objects are mapping of function name to string function source code. For


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Background indexing in CouchDB can be controlled on a
per-design document basis. This documents the option to
disable automatic indexing by specifying `autoupdate: false`
as a top level field in a design document.

## Testing recommendations

n/a

## GitHub issue number

## Related Pull Requests

#439 

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
