### PR TITLE
Add Kubernetes install instructions

### DIFF
--- a/src/install/docker.rst
+++ b/src/install/docker.rst
@@ -19,13 +19,13 @@ Installation via Docker
 Apache CouchDB provides 'convenience binary' Docker images through
 Docker Hub at ``apache/couchdb``. The following tags are available:
 
-* ``latest``, ``2.1.0``: CouchDB 2.1, single node
-* ``1``, ``1.6``, ``1.6.1``: CouchDB 1.6.1
-* ``1-couchperuser``, ``1.6-couchperuser``, ``1.6.1-couchperuser``: CouchDB
-  1.6.1 with couchperuser plugin
-* ``2.0.0``: CouchDB 2.0, single node
+* ``latest``, ``2``, ``2.3``, ``2.3.1``: CouchDB 2.3.1, single node
+* ``1``, ``1.7``, ``1.7.2``: CouchDB 1.7.2
+* ``1-couchperuser``, ``1.7-couchperuser``, ``1.7.2-couchperuser``: CouchDB
+  1.7.2 with couchperuser plugin
+* ``2.3.0``: CouchDB 2.3.0, single node
 
-These images are built using Debian 8 (jessie), expose CouchDB on port
+These images are built using Debian 9 (stretch), expose CouchDB on port
 ``5984`` of the container, run everything as user ``couchdb``, and support
 use of a Docker volume for data at ``/opt/couchdb/data``.
 

--- a/src/install/kubernetes.rst
+++ b/src/install/kubernetes.rst
@@ -10,21 +10,26 @@
 .. License for the specific language governing permissions and limitations under
 .. the License.
 
-.. _install:
+.. _install/kubernetes:
 
-============
-Installation
-============
+==========================
+Installation on Kubernetes
+==========================
 
-.. toctree::
-    :maxdepth: 2
+Apache CouchDB provides a `Helm chart`_ to enable deployment to
+Kubernetes.
 
-    unix
-    windows
-    mac
-    freebsd
-    docker
-    snap
-    kubernetes
-    upgrading
-    troubleshooting
+To install the chart with the release name ``my-release``:
+
+.. code-block:: sh
+
+    helm repo add couchdb https://apache.github.io/couchdb-helm
+
+    helm repo update
+
+    helm install --name my-release couchdb/couchdb
+
+Further details on the configuration options are available in
+the `Helm chart`_ readme.
+
+.. _Helm chart: https://hub.helm.sh/charts/couchdb/couchdb


### PR DESCRIPTION
## Overview

Adds a page with reference to the CouchDB helm chart. Given the
instructions for the Helm chart vary by release and are embedded
in each chart, I delegated to Helm Hub for the full configuration
/ documentation.

## Checklist

- [ ] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
