### PR TITLE
Document the IO Queue system

### DIFF
--- a/src/config/index.rst
+++ b/src/config/index.rst
@@ -27,6 +27,7 @@ Configuration
     auth
     compaction
     indexbuilds
+    ioq
     logging
     replicator
     query-servers

--- a/src/config/ioq.rst
+++ b/src/config/ioq.rst
@@ -1,0 +1,109 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. default-domain:: config
+.. highlight:: ini
+
+.. _config/ioq:
+
+========
+IO Queue
+========
+
+CouchDB has an internal subsystem that can prioritize IO associated with certain
+classes of operations. This subsystem can be configured to limit the resources
+devoted to background operations like internal replication and compaction
+according to the settings described below.
+
+.. config:section:: ioq :: IO Queue Configuration
+
+    .. config:option:: concurrency :: Number of in-flight IO requests
+
+        Specifies the maximum number of concurrent in-flight IO requests that
+        the queueing system will submit::
+
+            [ioq]
+            concurrency = 10
+
+    .. config:option:: ratio :: Preference for selecting background over interactive IO
+
+        The fraction of the time that a background IO request will be selected
+        over an interactive IO request when both queues are non-empty::
+
+            [ioq]
+            ratio = 0.01
+
+.. config:section:: ioq.bypass :: Bypass selected IO classes by setting these to true
+
+    System administrators can choose to submit specific classes of IO directly
+    to the underlying file descriptor or OS process, bypassing the queues
+    altogether. Installing a bypass can yield higher throughput and lower
+    latency, but relinquishes some control over prioritization. The following
+    classes are recognized:
+
+    .. config:option:: os_process
+
+        Messages on their way to an external process (e.g., ``couchjs``).
+
+    .. config:option:: read
+
+        Disk IO fulfilling interactive read requests.
+
+    .. config:option:: write
+
+        Disk IO required to update a database.
+
+    .. config:option:: view_update
+
+        Disk IO required to update views and other secondary indexes.
+
+    .. config:option:: shard_sync
+
+        Disk IO issued by the background replication processes that fix any
+        inconsistencies between shard copies.
+
+    .. config:option:: compaction
+
+        Disk IO issued by compaction jobs.
+
+    Without any configuration CouchDB will enqueue all classes of IO. The
+    default.ini configuration file that ships with CouchDB activates a bypass
+    for each of the interactive IO classes and only background IO goes into the
+    queueing system::
+
+        [ioq.bypass]
+        os_process = true
+        read = true
+        write = true
+        view_update = true
+        shard_sync = false
+        compaction = false
+
+Recommendations
+===============
+
+The default configuration protects against excessive IO from background
+operations like compaction disrupting the latency of interactive operations,
+while maximizing the overall IO throughput devoted to those interactive
+requests. There are certain situations where this configuration could be
+sub-optimal:
+
+* An administrator may want to devote a larger portion of the overall IO
+  bandwidth to compaction in order to stay ahead of the incoming write load. In
+  this it may be necessary to disable the bypass for ``write`` (to help with
+  database compaction) and/or ``view_update`` (to help with view index compaction)
+  and then increase the ``ratio`` to give compaction a higher priority.
+
+* A server with a large number of views that do not need to be comlpetely
+  up-to-date may benefit from removing the bypass on ``view_update`` in order to
+  optimize the latency for regular document read and write operations, and build
+  the views during quieter periods.


### PR DESCRIPTION
## Overview

This PR is a little bit different. It is not an accurate description of the current configuration for IOQ (which is far less coherent), but is rather an attempt to write down what I think the configuration ought to look like when we release 3.0. I've gone back and forth several times on how much we ought to modify and enhance IOQ at this late juncture, and figured one way to unblock things was to document what a sensible future state would look like.

The system I've documented here can be implemented with a conservative patch on top of the IOQ implementation that was present in CouchDB 2.3.1; i.e., it would ignore the "full fat" IOQ system later contributed by Cloudant. I expect that this approach will yield a higher-throughput system than "IOQ1" contributed by Cloudant and will be far less complex than "IOQ2". The documentation provides some basic recommendations regarding when it might make sense to change the defaults.

Other bits of the "full-fat" IOQ system that are excluded from this documentation:

- fine-grained prioritization of reads, writes, view updates, internal replication and compaction. Each of these classes has a bypass switch governing whether IOQ cares about it at all, and there's a single configuration knob balancing "interactive" (read, write, and view update) vs. "background" (internal replication and compaction) IO

- statistics collection and recording into an internal CouchDB database once a minute

- customization of priorities on a per-database basis

- deduplication of identical read IO requests that arrive concurrently. This dedupe operation is somewhat computationally expensive and we have sometimes needed to disable it in production

I'd like to use this Pull Request to gain support for IO Queue functionality as documented here as the plan of record for 3.0.

## GitHub issue number

apache/couchdb#2171

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
