### PR TITLE
Switch replicator "info" error message to be an object

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -1045,6 +1045,9 @@ error.
                     documents and ``_active_tasks`` to get a complete state
                     summary
 
+.. versionchanged:: 3.0.0 In error states the `"info"` field switched
+                    from being a string to being an object
+
 .. http:get:: /_scheduler/docs
     :synopsis: Retrieve information about replication documents from the
                ``_replicator`` database.
@@ -1074,9 +1077,10 @@ error.
     :>json string target: Replication target
     :>json string start_time: Timestamp of when the replication was started
     :>json string last_update: Timestamp of last state update
-    :>json object info: May contain additional information about the state.
-                        For error states, this will be a string. For success
-                        states this will contain a JSON object (see below).
+    :>json object info: Will contain additional information about the
+                        state. For errors, this will be an object with
+                        an `"error"` field and string value. For
+                        success states, see below.
     :>json number error_count: Consecutive errors count. Indicates how many
                                times in a row this replication has crashed.
                                Replication will be retried with an exponential
@@ -1210,9 +1214,10 @@ error.
     :>json string target: Replication target
     :>json string start_time: Timestamp of when the replication was started
     :>json string last_update: Timestamp of last state update
-    :>json object info: May contain additional information about the state.
-                        For error states, this will be a string. For success
-                        states this will contain a JSON object (see below).
+    :>json object info: Will contain additional information about the
+                        state. For errors, this will be an object with
+                        an `"error"` field and string value. For
+                        success states, see below.
     :>json number error_count: Consecutive errors count. Indicates how many
                                times in a row this replication has crashed.
                                Replication will be retried with an exponential
@@ -1311,9 +1316,10 @@ error.
     :>json string target: Replication target
     :>json string start_time: Timestamp of when the replication was started
     :>json string last_update: Timestamp of last state update
-    :>json object info: May contain additional information about the state.
-                        For error states, this will be a string. For success
-                        states this will contain a JSON object (see below).
+    :>json object info: Will contain additional information about the
+                        state. For errors, this will be an object with
+                        an `"error"` field and string value. For
+                        success states, see below.
     :>json number error_count: Consecutive errors count. Indicates how many
                                times in a row this replication has crashed.
                                Replication will be retried with an exponential

--- a/src/replication/replicator.rst
+++ b/src/replication/replicator.rst
@@ -207,7 +207,9 @@ crashes with an increasingly larger interval. The ``history`` list from
           "doc_id": "my_rep_crashing",
           "error_count": 6,
           "id": "cb78391640ed34e9578e638d9bb00e44+create_target",
-          "info": "db_not_found: could not open http://adm:*****@localhost:5984/missing/",
+          "info": {
+               "error": "db_not_found: could not open http://adm:*****@localhost:5984/missing/"
+          },
           "last_updated": "2017-04-05T20:55:10Z",
           "node": "node1@127.0.0.1",
           "source_proxy": null,
@@ -263,7 +265,9 @@ exactly why it failed:
             "doc_id": "my_rep_dup",
             "error_count": 1,
             "id": null,
-            "info": "Replication `a81a78e822837e66df423d54279c15fe+continuous+create_target` specified by document `my_rep_dup` already started, triggered by document `my_rep` from db `_replicator`",
+            "info": {
+                "error": "Replication `a81a78e822837e66df423d54279c15fe+continuous+create_target` specified by document `my_rep_dup` already started, triggered by document `my_rep` from db `_replicator`"
+            },
             "last_updated": "2017-04-05T21:41:51Z",
             "source": "http://myserver.com/foo/",
             "start_time": "2017-04-05T21:41:51Z",


### PR DESCRIPTION
Companion to the implementation PR https://github.com/apache/couchdb/pull/2379

### Overview

The value of the `"info"` field from the _scheduler/* API cannot be a string anymore. It is now restricted to be a `null` or a JSON object. 

### Related Pull Requests

https://github.com/apache/couchdb/pull/2379

### Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors