### PR TITLE
Update _stats configuration

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -1405,6 +1405,12 @@ error.
     statistic being easily identified, and the content of each statistic is
     self-describing.
 
+    Statistics are sampled internally on a :ref:`configurable interval
+    <config/stats>`. When monitoring the ``_stats`` endpoint, you need to use
+    a polling frequency of at least twice this to observe accurate results.
+    For example, if the :ref:`interval <config/stats>` is 10 seconds,
+    poll ``_stats`` at least every 5 seconds.
+
     The literal string ``_local`` serves as an alias for the local node name, so
     for all stats URLs, ``{node-name}`` may be replaced with ``_local``, to
     interact with the local node's statistics.
@@ -1504,7 +1510,8 @@ The type of the statistic is included in the ``type`` field, and is one of
 the following:
 
 - ``counter``: Monotonically increasing counter, resets on restart
-- ``histogram``: Binned set of values with meaningful subdivisions
+- ``histogram``: Binned set of values with meaningful subdivisions.
+  Scoped to the current :ref:`collection interval <config/stats>`.
 - ``gauge``: Single numerical value that can go up and down
 
 You can also access individual statistics by quoting the statistics sections

--- a/src/api/server/configuration.rst
+++ b/src/api/server/configuration.rst
@@ -108,8 +108,7 @@ interact with the local node's configuration.
                 "max_http_sessions": "10"
             },
             "stats": {
-                "rate": "1000",
-                "samples": "[0, 60, 300, 900]"
+                "interval": "10"
             },
             "uuids": {
                 "algorithm": "utc_random"

--- a/src/config/misc.rst
+++ b/src/config/misc.rst
@@ -49,20 +49,12 @@ Statistic Calculation
 
 .. config:section:: stats :: Statistic Calculation
 
-    .. config:option:: rate
+    .. config:option:: interval
 
-        Rate of statistics gathering in milliseconds::
-
-            [stats]
-            rate = 1000
-
-    .. config:option:: samples
-
-        Samples are used to track the mean and standard value deviation within
-        specified intervals (in seconds)::
+        Interval between gathering statistics in seconds::
 
             [stats]
-            samples = [0, 60, 300, 900]
+            interval = 10
 
 .. _config/uuids:
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Documents the `stats.interval` configuration key and remove
the redundant `rate` and `samples` keys.

Additionally, adds a note about how `histogram` types interact
with the collection interval and how `_stats` should be safely
consumed to avoid lossy sampling.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

n/a

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
