### PR TITLE
Document Mango configuration options

### DIFF
--- a/src/config/query-servers.rst
+++ b/src/config/query-servers.rst
@@ -227,3 +227,44 @@ CouchDB's search subsystem can be configured via the ``dreyfus`` configuration s
         database. Attempts to set ``?limit=N`` higher than this value will be rejected. If
         this config setting is not defined, CouchDB will use the value of ``max_limit``
         instead. If neither is defined, the default is ``2000``.
+
+.. _config/mango:
+
+Mango
+=====
+
+Mango is the Query Engine that services the :ref:`_find <api/db/_find>`, endpoint.
+
+.. config:section:: mango :: Mango Configuration
+
+    .. config:option:: index_all_disabled :: Disable "index all fields" behaviour
+
+        Set to ``true`` to disable the "index all fields" text index. This can lead
+        to out of memory issues when there are documents with nested array fields.
+        Defaults to ``false``.
+
+            [mango]
+            index_all_disabled = false
+
+    .. config:option:: default_limit :: Default limit value for Mango queries.
+
+        Sets the default number of results that will be returned in a
+        :ref:`_find <api/db/_find>` response. Individual requests can override this
+        by setting ``limit`` directly in the query parameters.
+        Defaults to ``25``.
+
+            [mango]
+            default_limit = 25
+
+    .. config:option:: index_scan_warning_threshold :: Ratio threshold that generates an
+       index scan warning
+
+        This sets the ratio between documents scanned and results matched that
+        will generate a warning in the _find response. For example, if a query
+        requires reading 100 documents to return 10 rows, a warning will be
+        generated if this value is ``10``.
+
+        Defaults to ``10``. Setting the value to ``0`` disables the warning.
+
+            [mango]
+            index_scan_warning_threshold = 10


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Adds documentation for the Mango configuration options:

 * mango.index_all_disabled
 * mango.default_limit
 * mango.index_scan_warning_threshold

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
