### PR TITLE
Document same_site cookie attribute

### DIFF
--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -144,6 +144,16 @@ Authentication Configuration
             [couch_httpd_auth]
             cookie_domain = example.com
 
+    .. config:option:: same_site :: SameSite
+
+        .. versionadded:: 3.0.0
+
+        When this option is set to a non-empty value, a ``SameSite`` attribute is added to
+        the ``AuthSession`` cookie. Valid values are ``none``, ``lax`` or ``strict``.::
+
+            [couch_httpd_auth]
+            same_site = strict
+
     .. config:option:: auth_cache_size :: Authentication cache
 
         Number of :ref:`userctx_object` to cache in memory, to reduce disk


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add documentation for configuring the SameSite attribute of the
auth cookie.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

Refs #2221

## Related Pull Requests

https://github.com/apache/couchdb/pull/2452

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
