### PR TITLE
Document _config/_reload endpoint

### DIFF
--- a/src/api/server/configuration.rst
+++ b/src/api/server/configuration.rst
@@ -293,3 +293,37 @@ interact with the local node's configuration.
         Server: CouchDB (Erlang/OTP)
 
         "info"
+
+.. _api/config/reload:
+
+``_node/{node-name}/_config/_reload``
+=====================================
+
+.. versionadded:: 3.0
+
+.. http:post:: /_node/{node-name}/_config/_reload
+    :synopsis: Reload the configuration from disk
+
+    Reloads the configuration from disk. This has a side effect of
+    flushing any in-memory configuration changes that have not been
+    committed to disk.
+
+    **Request**:
+
+    .. code-block:: http
+
+        POST /_node/nonode@nohost/_config/_reload HTTP/1.1
+        Host: localhost:5984
+
+    **Response**:
+
+    .. code-block:: http
+
+        HTTP/1.1 200 OK
+        Cache-Control: must-revalidate
+        Content-Length: 12
+        Content-Type: application/json
+        Date: Tues, 21 Jan 2020 11:09:35
+        Server: CouchDB/3.0.0 (Erlang OTP)
+
+        {"ok":true}


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add documentation for the _node/<node>/_config/_reload endpoint.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

n/a

## Related Pull Requests

https://github.com/apache/couchdb/pull/2475

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
