### PR TITLE
Fix typo in `_scheduler/docs`

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -1086,7 +1086,7 @@ error.
     :>json string source: Replication source
     :>json string target: Replication target
     :>json string start_time: Timestamp of when the replication was started
-    :>json string last_update: Timestamp of last state update
+    :>json string last_updated: Timestamp of last state update
     :>json object info: Will contain additional information about the
                         state. For errors, this will be an object with
                         an `"error"` field and string value. For


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The response description for `_scheduler/docs` says there's a key `last_update`, however there isn't one. There is a `last_updated` instead, just as it shows in the example right below.

This change fixes the issue described above.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Query `_scheduler/docs` and observe the response.



## Checklist

- [X] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
