### PR TITLE
Document Windows installer improvements

### DIFF
--- a/src/install/windows.rst
+++ b/src/install/windows.rst
@@ -23,6 +23,10 @@ Installation from binaries
 
 This is the simplest way to go.
 
+.. warning::
+    Windows 10 requires the .NET Framwork v3.5 to be installed. You can install
+    this via the `Control Panel`_.
+
 #. Get `the latest Windows binaries`_ from the `CouchDB web site`_.
    Old releases are available at `archive`_.
 
@@ -57,6 +61,41 @@ This is the simplest way to go.
 .. _CouchDB web site: http://couchdb.org/
 .. _archive: http://archive.apache.org/dist/couchdb/binary/win/
 .. _the latest Windows binaries: http://couchdb.org/#download
+.. _Control Panel: https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10
+
+.. _install/windows/silent:
+
+Silent Install
+--------------
+
+The Windows installer supports silent installs. Here are some sample commands, supporting
+the new features of the 3.0 installer.
+
+Install CouchDB without a service, but with an admin user:password of ``admin:hunter2``:
+
+.. code-block:: batch
+
+    msiexec /i apache-couchdb-3.0.0.msi /quiet ADMINUSER=admin ADMINPASSWORD=hunter2 /norestart
+
+The same as above, but also install and launch CouchDB as a service:
+
+.. code-block:: batch
+
+    msiexec /i apache-couchdb-3.0.0.msi /quiet INSTALLSERVICE=1 ADMINUSER=admin ADMINPASSWORD=hunter2 /norestart
+
+Unattended uninstall of CouchDB:
+
+.. code-block:: batch
+
+    msiexec /x apache-couchdb-3.0.0.msi /quiet /norestart
+
+Unattended uninstall if the installer file is unavailable:
+
+.. code-block:: batch
+
+    msiexec /x {4CD776E0-FADF-4831-AF56-E80E39F34CFC} /quiet /norestart
+
+Add ``/l* log.txt`` to any of the above to generate a useful logfile for debugging.
 
 Installation from sources
 =========================

--- a/src/whatsnew/3.0.rst
+++ b/src/whatsnew/3.0.rst
@@ -217,6 +217,17 @@ Features and Enhancements
   2.x. As OSes update to include binaries for SM 60, the convenience binaries will be
   updated accordingly.
 
+* The Windows installer has many improvements, including:
+
+  * Prompts for an admin user/password as CouchDB 3.0 requires
+    * Will not overwrite existing credentials if in place
+  * No longer remove user-modified config files, closing :ghissue:`1989`
+    * Also will not overwrite them on install.
+  * Checkbox to disable installation of the Windows service
+  * :ref:`Silent install support <install/windows/silent>`.
+  * Friendly link to these online release notes in the exit dialog
+  * Higher resolution icon for HiDPI (500x500)
+
 * :ghissue:`2037`: Dreyfus, the CouchDB side of the Lucene-powered search solution, is now
   shipped with CouchDB. When one or more Clouseau Java nodes are joined to the cluster,
   text-based indexes can be enabled in CouchDB. It is recommended to have as many Clouseau


### PR DESCRIPTION
Since we're cutting 3.0.0-RC2...let's document the Windows installer improvements.

We'll then tag this as `3.0.0-RC2` and we can reference that in `rebar.config.script` instead, which allows us to move `3.0.0` if we need to.