### PR TITLE
New smoosh defaults for 3.0.1

### DIFF
--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -235,11 +235,11 @@ configuration setting in the `[smoosh]` block. The default configuration is
 
     [smoosh.ratio_dbs]
     priority = ratio
-    min_priority = 5.0
+    min_priority = 2.0
 
     [smoosh.ratio_views]
     priority = ratio
-    min_priority = 5.0
+    min_priority = 2.0
 
     [smoosh.slack_dbs]
     priority = slack


### PR DESCRIPTION
## Overview

Docs bump for the change in https://github.com/apache/couchdb/pull/2678 .
