### PR TITLE
Update Getting Started section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,14 @@ You can view the latest rendered build of this content at:
 
     http://docs.couchdb.org/en/latest
 
-# Getting Started
+# Building the Repo
 
-## Prerequisites
-
-- Python 3.x
-- Pip
-
-### Preparing Prerequisites using [asdf](https://asdf-vm.com/#/)
+Install Python3 and pip. Then:
 
 ```sh
-$ asdf plugin add python
-$ asdf install python 3.8.2
-$ pip pip install -r requirements.txt
-$ asdf reshim python
-```
-### Preparing Prerequisites having Python/Pip already installed
-
-```sh
+$ python3 -m venv .venv
+$ source .venv/bin/activate
 $ pip install -r requirements.txt
-```
-
-## Building the Repo
-
-```sh
 $ make html # builds the docs
 $ make check # syntax checks the docs
 ```

--- a/README.md
+++ b/README.md
@@ -5,17 +5,34 @@ You can view the latest rendered build of this content at:
 
     http://docs.couchdb.org/en/latest
 
-# Building this repo
+# Getting Started
 
-Install Python 2.7+ and pip. Then:
+## Prerequisites
+
+- Python 3.x
+- Pip
+
+### Preparing Prerequisites using [asdf](https://asdf-vm.com/#/)
 
 ```sh
-$ virtualenv venv
-$ . ./venv/bin/activate
+$ asdf plugin add python
+$ asdf install python 3.8.2
+$ pip pip install -r requirements.txt
+$ asdf reshim python
+```
+### Preparing Prerequisites having Python/Pip already installed
+
+```sh
 $ pip install -r requirements.txt
+```
+
+## Building the Repo
+
+```sh
 $ make html # builds the docs
 $ make check # syntax checks the docs
 ```
+
 # Feedback, Issues, Contributing
 
 General feedback is welcome at our [user][1] or [developer][2] mailing lists.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ You can view the latest rendered build of this content at:
 
     http://docs.couchdb.org/en/latest
 
-# Building the Repo
+# Building this repo
 
 Install Python3 and pip. Then:
 


### PR DESCRIPTION
Remove outdated reference on `virtualenv` and Python 2.7

## Testing recommendations

Go through the documented steps.

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
