### PR TITLE
Fix _all_docs/queries example result

### DIFF
--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -396,18 +396,13 @@ Sending multiple queries to a database
             {
                 "rows": [
                     {
-                        "id": "SpaghettiWithMeatballs",
+                        "id": "meatballs",
                         "key": "meatballs",
                         "value": 1
                     },
                     {
-                        "id": "SpaghettiWithMeatballs",
+                        "id": "spaghetti",
                         "key": "spaghetti",
-                        "value": 1
-                    },
-                    {
-                        "id": "SpaghettiWithMeatballs",
-                        "key": "tomato sauce",
                         "value": 1
                     }
                 ],


### PR DESCRIPTION
## Overview

The example result for _all_docs/queries did not match the example request and it was incorrect in a sense that the values `id` fields were not matching the respective values of `key` fields and there was a document returned that was not specified in the query.

This change fixes the issue described above by editing the ids so that they match the keys now and removing the element that was not specified in the request.


## Checklist

- [x] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
