### PR TITLE
Add note of ddoc autoupdate:false to ken config

### DIFF
--- a/src/config/indexbuilds.rst
+++ b/src/config/indexbuilds.rst
@@ -59,3 +59,7 @@ over specific database shard files. The key must be the exact name of the shard 
 
         [ken.ignore]
         shards/00000000-1fffffff/mydb.1567719095 = true
+
+    .. note::
+        In case when you'd like to skip all views from a ddoc, you may add
+        ``autoupdate: false`` to the doc using :put:`/{db}/_design/{ddoc}`.

--- a/src/config/indexbuilds.rst
+++ b/src/config/indexbuilds.rst
@@ -62,4 +62,6 @@ over specific database shard files. The key must be the exact name of the shard 
 
     .. note::
         In case when you'd like to skip all views from a ddoc, you may add
-        ``autoupdate: false`` to the doc using :put:`/{db}/_design/{ddoc}`.
+        ``autoupdate: false`` to the ddoc. All views of that ddoc will then be skipped.
+
+        More at :http:put:`/{db}/_design/{ddoc}`.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
When looking for ways to control background indexing, users usually land on [3.8. Background Indexing](https://docs.couchdb.org/en/3.0.0/config/indexbuilds.html).
But if they are looking for a way to disable background indexing of a specific ddoc or view, that option (`autoupdate`) is documented in the [ddoc API](https://docs.couchdb.org/en/3.0.0/api/ddoc/common.html#put--db-_design-ddoc).

This pull request adds a note about `autoupdate:false` and a link from background indexing to the ddoc API.

## Testing recommendations

Decide if a `Note` or `See also` is more appropriate.

## GitHub issue number

There is no bug. It is probably not a significant change.

## Checklist

- [ ] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
