### PR TITLE
Fix PUT attachment documentation

### DIFF
--- a/src/api/document/attachments.rst
+++ b/src/api/document/attachments.rst
@@ -131,7 +131,7 @@
     :param docid: Document ID
     :param attname: Attachment name
 
-    :<header Content-Type: Attachment MIME type. *Required*
+    :<header Content-Type: Attachment MIME type. Default: "application/octet-stream" *Optional*
     :<header If-Match: Document revision. Alternative to `rev` query parameter
 
     :query string rev: Document revision. *Optional*

--- a/src/api/document/attachments.rst
+++ b/src/api/document/attachments.rst
@@ -131,7 +131,7 @@
     :param docid: Document ID
     :param attname: Attachment name
 
-    :<header Content-Type: Attachment MIME type. Default: "application/octet-stream" *Optional*
+    :<header Content-Type: Attachment MIME type. Default: :mimetype:`application/octet-stream` *Optional*
     :<header If-Match: Document revision. Alternative to `rev` query parameter
 
     :query string rev: Document revision. *Optional*


### PR DESCRIPTION
## Overview

According to https://docs.couchdb.org/en/stable/api/document/attachments.html#put--db-docid-attname Content-Type is a required header in case of adding new attachment.
However, attachments can be created without specifying the content type

## Testing recommendations

Create attachment without providing Content-Type header.
Eg:
```
$ curl -X PUT -v 172.17.0.2:5984/mydatabase/doc4/aab.jpg  --upload-file README.txt 
{ [67 bytes data]
{"ok":true,"id":"doc4","rev":"1-8a5b4ad6f236295aeb5a52edb8f27470"}
100  5956  100    67  100  5889   2310   198k --:--:-- --:--:-- --:--:--  207k
* Closing connection 0
```

## GitHub issue number

Fixes #507 Content-type header is not required when putting attachments

## Checklist

- [x] Documentation is written and is accurate;
- [x] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
