### PR TITLE
511 extending clouseau plugin doc

### DIFF
--- a/src/install/search.rst
+++ b/src/install/search.rst
@@ -36,11 +36,11 @@ available on `GitHub`_.  The files in each release should be unpacked into a dir
 the Java classpath. If you do not have a classpath already set, or you wish to explicitly
 set the classpath location for Clouseau, then add the line::
 
--classpath '/path/to/clouseau/*'
+    -classpath '/path/to/clouseau/*'
 
 to the server command below. If clouseau is installed in ``/opt/clouseau`` the line would be::
 
--classpath '/opt/clouseau'
+    -classpath '/opt/clouseau/*'
 
 The service expects to find a couple of configuration files
 conventionally called ``clouseau.ini`` and ``log4j.properties`` with the following

--- a/src/install/search.rst
+++ b/src/install/search.rst
@@ -38,7 +38,7 @@ set the classpath location for Clouseau, then add the line::
 
 -classpath '/path/to/clouseau/*'
 
-to the server command below. If clouseau is installed in /opt/clouseau the line would be::
+to the server command below. If clouseau is installed in ``/opt/clouseau`` the line would be::
 
 -classpath '/opt/clouseau'
 

--- a/src/install/search.rst
+++ b/src/install/search.rst
@@ -33,7 +33,16 @@ Installation of Binary Packages
 
 Binary packages that bundle all the necessary dependencies of the search plugin are
 available on `GitHub`_.  The files in each release should be unpacked into a directory on
-the Java classpath. The service expects to find a couple of configuration files
+the Java classpath. If you do not have a classpath already set, or you wish to explicitly
+set the classpath location for Clouseau, then add the line::
+
+-classpath '/path/to/clouseau/*'
+
+to the server command below. If clouseau is installed in /opt/clouseau the line would be::
+
+-classpath '/opt/clouseau'
+
+The service expects to find a couple of configuration files
 conventionally called ``clouseau.ini`` and ``log4j.properties`` with the following
 content:
 


### PR DESCRIPTION
Added a sentence n explicitly setting the classpath in te server parameters when running the service.
## Overview
Issue `[511](https://github.com/apache/couchdb-documentation/issues/511)` asks for elaboration of the Search Plugin documentation page. This pull request amends the current documentation.

## Testing recommendations
Check out the 511-extend-clouseau-pugin-doc branch and run Sphinx to generate the documentation. 

`make check` should have no output.

Go to the couchdb-documentation/build/html/install/search.html#install-search and see the result in the browser.

## GitHub issue number

Fixes [511](https://github.com/apache/couchdb-documentation/issues/511)

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
