### PR TITLE
Correct the occurrence of _global_changes

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -338,7 +338,7 @@
                      - :mimetype:`text/plain`
     :query array ensure_dbs_exist: List of system databases to ensure exist
         on the node/cluster. Defaults to
-        ``["_users","_replicator","_global_changes"]``.
+        ``["_users","_replicator"]``.
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
     :>json string state: Current ``state`` of the node and/or cluster (see
@@ -437,7 +437,7 @@
         (add_node only)
     :<json array ensure_dbs_exist: List of system databases to ensure exist
         on the node/cluster. Defaults to
-        ``["_users","_replicator","_global_changes"]``.
+        ``["_users","_replicator"]``.
 
     *No example request/response included here. For a worked example, please
     see* :ref:`cluster/setup/api`.
@@ -453,7 +453,9 @@
 .. http:get:: /_db_updates
     :synopsis: Return the server changes of databases
 
-    Returns a list of all database events in the CouchDB instance.
+    Returns a list of all database events in the CouchDB instance. The
+    existence of the ``_global_changes`` database is required to use this
+    endpoint.
 
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`text/plain`


### PR DESCRIPTION
## Overview

This PR intended to solve the missing document modifications from https://github.com/apache/couchdb/issues/2497. (Unfortunately, GitHub does not allow me to open the issue).

As per the 3.0.1 upgrade notes says
> The setup wizard no longer automatically creates the `_global_changes` database, as the majority of users do not need this functionality. This reduces overall CouchDB load.

If I am correct this means the default values of the `ensure_dbs_exist` property reduced from `["_users","_replicator","_global_changes"]` to `["_users","_replicator"]` at the `/_cluster_setup`. Moreover `/_db_updates` cannot be reached till the `_global_changes` database is not created beforehand.

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->