### PR TITLE
Update ddocs.rst

### DIFF
--- a/src/ddocs/ddocs.rst
+++ b/src/ddocs/ddocs.rst
@@ -97,7 +97,7 @@ Reduce and Rereduce Functions
 
 .. function:: redfun(keys, values[, rereduce])
 
-    :param keys: Array of pairs of docid-key for related map function results.
+    :param keys: Array of pairs of key-docid for related map function results.
                  Always ``null`` if rereduce is running (has ``true`` value).
     :param values: Array of map function result values.
     :param rereduce: Boolean flag to indicate a rereduce run.


### PR DESCRIPTION
Improvement to "3.1.2.2. Reduce and Rereduce Functions" argument description #517

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Currently, under 3.1.2.2. Reduce and Rereduce Functions, the description of the keys argument is:
Array of pairs of docid-key for related map function results. Always null if rereduce is running (has true value).
The correct representation would be if the documentation says key-docid instead of docid-key

## Testing recommendations

Documentaion Correction. No testing required

## GitHub issue number

Closes https://github.com/apache/couchdb-documentation/issues/517

## Related Pull Requests

None

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
