### PR TITLE
Freshen Docker install info

### DIFF
--- a/src/install/docker.rst
+++ b/src/install/docker.rst
@@ -17,20 +17,22 @@ Installation via Docker
 =======================
 
 Apache CouchDB provides 'convenience binary' Docker images through
-Docker Hub at ``apache/couchdb``. The following tags are available:
+Docker Hub at ``apache/couchdb``. This is our upstream release; it
+is usually mirrored downstream at Docker's top-level ``couchdb``
+as well.
 
-* ``latest``, ``3``, ``3.0``, ``3.0.0``: CouchDB 3.0.0, single node
-* ``2``, ``2.3``, ``2.3.1``: CouchDB 2.3.1, single node
-* ``1``, ``1.7``, ``1.7.2``: CouchDB 1.7.2
+At least these tags are always available on the image:
+
+* ``latest`` - always the latest
+* ``3``: always the latest 3.x version
+* ``2``: always the latest 2.x version
+* ``1``, ``1.7``, ``1.7.2``: CouchDB 1.7.2 (convenience only; no longer supported)
 * ``1-couchperuser``, ``1.7-couchperuser``, ``1.7.2-couchperuser``: CouchDB
-  1.7.2 with couchperuser plugin
+  1.7.2 with couchperuser plugin (convenience only; no longer supported)
 
-These images are built using Debian 9 (stretch), expose CouchDB on port
-``5984`` of the container, run everything as user ``couchdb``, and support
-use of a Docker volume for data at ``/opt/couchdb/data``.
-
-Note that you can also use the ``NODENAME`` environment variable to set the
-name of the CouchDB node inside the container.
+These images expose CouchDB on port ``5984`` of the container, run everything
+as user ``couchdb`` (uid ``5984``), and support use of a Docker volume for data
+at ``/opt/couchdb/data``.
 
 **Your installation is not complete. Be sure to complete the**
 :ref:`Setup <setup>` **steps for a single node or clustered installation.**


### PR DESCRIPTION
## Overview

This will prevent us from having to bump the versions in this section again until 4.0.