### PR TITLE
Add missing word "key" in "What is a partition?"

### DIFF
--- a/src/partitioned-dbs/index.rst
+++ b/src/partitioned-dbs/index.rst
@@ -103,7 +103,7 @@ What is a partition?
 In the previous section, we introduced a hypothetical database that contains
 sensor readings from an IoT field monitoring service. In this particular
 use case, it's quite logical to group all documents by their ``sensor_id``
-field. In this case, we would call the ``sensor_id`` the partition.
+field. In this case, we would call the ``sensor_id`` the partition key.
 
 A good partition has two basic properties. First, it should have a high
 cardinality. That is, a large partitioned database should have many more


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

I assume the author intended to write that sensor_id was the partition key, since it doesn't make sense to me how a field could be a partition.

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
