### PR TITLE
apt-transport-https has become a dummy package as of Debian 10/Ubuntu 18.04.

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -65,7 +65,7 @@ Enabling the Apache CouchDB package repository
 
 **Debian 10 (buster)**: Run the following commands::
 
-    $ sudo apt-get install -y apt-transport-https gnupg ca-certificates
+    $ sudo apt-get install -y gnupg ca-certificates
     $ echo "deb https://apache.bintray.com/couchdb-deb buster main" \
         | sudo tee -a /etc/apt/sources.list.d/couchdb.list
 
@@ -77,13 +77,13 @@ Enabling the Apache CouchDB package repository
 
 **Ubuntu 18.04 (Bionic)**: Run the following commands::
 
-    $ sudo apt-get install -y apt-transport-https gnupg ca-certificates
+    $ sudo apt-get install -y gnupg ca-certificates
     $ echo "deb https://apache.bintray.com/couchdb-deb bionic main" \
         | sudo tee -a /etc/apt/sources.list.d/couchdb.list
 
 **Ubuntu 20.04 (Focal)**: Run the following commands::
 
-    $ sudo apt-get install -y apt-transport-https gnupg ca-certificates
+    $ sudo apt-get install -y gnupg ca-certificates
     $ echo "deb https://apache.bintray.com/couchdb-deb focal main" \
         | sudo tee -a /etc/apt/sources.list.d/couchdb.list
 


### PR DESCRIPTION
## Overview
Remove apt-transport-https from to-be-installed packages for Debian >= 10 and Ubuntu >= 18.04, since that functionality has been moved into the main apt package and apt-transport-https became a dummy package.