### PR TITLE
Fix method type to POST in /{db}/_partition/{partition_id}/_explain and /{db}/_partition/{partition_id}/_find

### DIFF
--- a/src/api/partitioned-dbs.rst
+++ b/src/api/partitioned-dbs.rst
@@ -199,7 +199,7 @@ See the guide for
 ``/db/_partition/partition_id/_find``
 =====================================
 
-.. http:get:: /{db}/_partition/{partition_id}/_find
+.. http:post:: /{db}/_partition/{partition_id}/_find
     :synopsis: Query the partition specified by ``partition_id``
 
     :param db: Database name
@@ -218,7 +218,7 @@ See the guide for
 ``/db/_partition/partition_id/_explain``
 ========================================
 
-.. http:get:: /{db}/_partition/{partition_id}/_explain
+.. http:post:: /{db}/_partition/{partition_id}/_explain
     :synopsis: Find index that is used with a query
 
     :param db: Database name


### PR DESCRIPTION
## Overview

I was facing [/{db}/_partition/{partition_id}/_find](https://docs.couchdb.org/en/stable/api/partitioned-dbs.html?highlight=_partition#get--db-_partition-partition_id-_find) and [/{db}/_partition/{partition_id}/_explain](https://docs.couchdb.org/en/stable/api/partitioned-dbs.html?highlight=_partition#get--db-_partition-partition_id-_explain) were documented as `GET` methods, however both of them are `POST`. I was testing them and both returned with the following when I was using `GET`:
```
curl --location --request GET 'localhost:5984/{db}/_partition/{partition}/_explain' \
--header 'Authorization: Basic ***'
```

```
curl --location --request GET 'localhost:5984/{db}/_partition/{partition}/_find' \
--header 'Authorization: Basic ***'
```

```json
{
    "error": "method_not_allowed",
    "reason": "Only POST allowed"
}
``` 

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged