### PR TITLE
Add max_history to replicator config

### DIFF
--- a/src/config/replicator.rst
+++ b/src/config/replicator.rst
@@ -66,6 +66,17 @@ Replicator Database Configuration
              [replicator]
              max_churn = 20
 
+    .. config:option:: max_history
+
+        Maximum number of events recorded for each job. This parameter defines
+        an upper bound on the consecutive failure count for a job, and in turn
+        the maximum backoff factor used when determining the delay before the job
+        is restarted. The longer the length of the crash count, the longer the
+        possible length of the delay::
+
+             [replicator]
+             max_history = 20
+
     .. config:option:: update_docs
 
         .. versionadded:: 2.1


### PR DESCRIPTION
## Overview

Adds `max_history` parameter to documentation for configuring replicator database.

Cross-referencing with main CouchDB repo shows that `max_history` is a configurable parameter in CouchDB 3.1. (see [couch_replicator_scheduler#L238](https://github.com/apache/couchdb/blob/4e64f5b492990b03f7f58a47ec173d048a3f381f/src/couch_replicator/src/couch_replicator_scheduler.erl#L238)). 

While researching CouchDB's offline-first functionality in environments of low and/or intermittent connectivity, one of the main issues was the possible length of the delay between replication jobs due to the exponential back-off algorithm. In environments where users have unreliable and intermittent connectivity, it is important that replication restarts quickly when network connectivity is established.

One possible solutions is given in an issue in the main repo [here](https://github.com/apache/couchdb/issues/1399). The solution involves adjusting the ` [replicator]max_history` parameter to reduce the maximum back-off factor used to calculate the delay before a job is restarted. I noticed that this parameter was not included in the public documentation, and thought it would be helpful to include it for users wanting to use CouchDB in environments where it is helpful to have shorter delays between replication jobs.

## Testing recommendations

`make check`.

## GitHub issue number

#552.

## Related Pull Requests

N/A.

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged