### PR TITLE
Update couch-peruser.rst

### DIFF
--- a/src/config/couch-peruser.rst
+++ b/src/config/couch-peruser.rst
@@ -44,6 +44,7 @@ couch_peruser Options
 
         [couch_peruser]
         delete_dbs = false
-        
-    Note: When using JWT authorization, the provided token must include a custom _couchdb.roles=['_admin'] claim to for
-    the peruser database to be properly created and accessible for the user provided in the sub= claim
+
+    Note: When using JWT authorization, the provided token must include a custom
+    ``_couchdb.roles=['_admin']`` claim to for the peruser database to be properly
+    created and accessible for the user provided in the ``sub=`` claim.

--- a/src/config/couch-peruser.rst
+++ b/src/config/couch-peruser.rst
@@ -44,3 +44,6 @@ couch_peruser Options
 
         [couch_peruser]
         delete_dbs = false
+        
+    Note: When using jwt authorization, the provided token must include a custom _couchdb.roles=['_admin'] claim to for
+    the peruser database to be properly created and accessible for the user provided in the sub= claim

--- a/src/config/couch-peruser.rst
+++ b/src/config/couch-peruser.rst
@@ -45,5 +45,5 @@ couch_peruser Options
         [couch_peruser]
         delete_dbs = false
         
-    Note: When using jwt authorization, the provided token must include a custom _couchdb.roles=['_admin'] claim to for
+    Note: When using JWT authorization, the provided token must include a custom _couchdb.roles=['_admin'] claim to for
     the peruser database to be properly created and accessible for the user provided in the sub= claim


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Added information on couch_peruser in a jwt environment, specifically the need to include an admin role claim.


