### PR TITLE
Allow drilldown for search to always be specified as list of lists

### DIFF
--- a/src/ddocs/search.rst
+++ b/src/ddocs/search.rst
@@ -814,7 +814,7 @@ Drilldown
 You can restrict results to documents with a dimension equal to the specified label.
 Restrict the results by adding ``drilldown=["dimension","label"]`` to a search query. You
 can include multiple ``drilldown`` parameters to restrict results along multiple
-dimensions.
+dimensions: ``drilldown=[["dimension1","label1"], ["dimension2","label2"]]``
 
 Using a ``drilldown`` parameter is similar to using ``key:value`` in the ``q`` parameter,
 but the ``drilldown`` parameter returns values that the analyzer might skip.

--- a/src/ddocs/search.rst
+++ b/src/ddocs/search.rst
@@ -814,7 +814,22 @@ Drilldown
 You can restrict results to documents with a dimension equal to the specified label.
 Restrict the results by adding ``drilldown=["dimension","label"]`` to a search query. You
 can include multiple ``drilldown`` parameters to restrict results along multiple
-dimensions: ``drilldown=[["dimension1","label1"], ["dimension2","label2"]]``
+dimensions.
+
+.. code-block:: http
+
+    GET /things/_design/inventory/_search/fruits?q=*:*&drilldown=["state","old"]&drilldown=["item","apple"]&include_docs=true HTTP/1.1
+
+For better language interoperability, you can achieve the same by supplying a list of lists:
+
+.. code-block:: http
+
+    GET /things/_design/inventory/_search/fruits?q=*:*&drilldown=[["state","old"],["item","apple"]]&include_docs=true HTTP/1.1
+
+You can also supply a list of lists for ``drilldown`` in bodies of POST requests.
+
+Note that, multiple values for a single key in a ``drilldown`` means an
+``OR`` relation between them and there is an ``AND`` relation between multiple keys.
 
 Using a ``drilldown`` parameter is similar to using ``key:value`` in the ``q`` parameter,
 but the ``drilldown`` parameter returns values that the analyzer might skip.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

To use multiple `drilldown` parameters users had to define
`drilldown` multiple times to be able supply them.

This caused interoperability issues as most languages require
defining query parameters and request bodies as associative
arrays, maps or dictionaries where the keys are unique.

This change enables defining `drilldown` as a list of lists so
that other languages can define multiple drilldown keys and values.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

`make check` passed for me locally

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

This is related to https://github.com/apache/couchdb/pull/2958

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
