### PR TITLE
Add JWT authentication to list in docs

### DIFF
--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -89,6 +89,7 @@ HTTP Server Options
 
         - ``{chttpd_auth, cookie_authentication_handler}``: used for Cookie auth;
         - ``{chttpd_auth, proxy_authentication_handler}``: used for Proxy auth;
+        - ``{chttpd_auth, jwt_authentication_handler}``: used for JWT auth;
         - ``{chttpd_auth, default_authentication_handler}``: used for Basic auth;
         - ``{couch_httpd_auth, null_authentication_handler}``: disables auth, breaks CouchDB.
 


### PR DESCRIPTION
Add JWT authentication as an option in the list under the 'authentication handlers' section in the docs