### PR TITLE
Key name correction in ddoc example

### DIFF
--- a/src/ddocs/ddocs.rst
+++ b/src/ddocs/ddocs.rst
@@ -42,7 +42,7 @@ Design documents are denoted by an id field with the format ``_design/{name}``.
 .. code-block:: json
 
     {
-        "id": "_design/example",
+        "_id": "_design/example",
     }
 
 .. _viewfun:


### PR DESCRIPTION
A simple mistake in the key name in a ddoc example.