### PR TITLE
Rename missed_revs to missing_revs in {db}/_missing_revs result

### DIFF
--- a/src/api/database/misc.rst
+++ b/src/api/database/misc.rst
@@ -328,7 +328,7 @@ following behavior:
         Server: CouchDB (Erlang/OTP)
 
         {
-            "missed_revs":{
+            "missing_revs":{
                 "c6114c65e295552ab1019e2b046b10e": [
                     "3-b06fcd1c1c9e0ec7c480ee8aa467bf3b"
                 ]


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
In the return object of `POST /{db}/_missing_revs` there is no `missed_revs` field.
`missing_revs` field is returned.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Send a `POST /{db}/_missing_revs` request and the response object will contain `missing_revs` field.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
