### PR TITLE
New Mango operator documentation (match keys of a map)

### DIFF
--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -419,37 +419,41 @@ Combination Operators
 Combination operators are used to combine selectors. In addition to the common
 boolean operators found in most programming languages, there are three
 combination operators (``$all``, ``$elemMatch``, and ``$allMatch``) that help
-you work with JSON arrays.
+you work with JSON arrays and one that works with JSON maps (``$keyMapMatch``).
 
 A combination operator takes a single argument. The argument is either another
 selector, or an array of selectors.
 
 The list of combination operators:
 
-+----------------+----------+--------------------------------------------------+
-| Operator       | Argument | Purpose                                          |
-+================+==========+==================================================+
-| ``$and``       | Array    | Matches if all the selectors in the array match. |
-+----------------+----------+--------------------------------------------------+
-| ``$or``        | Array    | Matches if any of the selectors in the array     |
-|                |          | match. All selectors must use the same index.    |
-+----------------+----------+--------------------------------------------------+
-| ``$not``       | Selector | Matches if the given selector does not match.    |
-+----------------+----------+--------------------------------------------------+
-| ``$nor``       | Array    | Matches if none of the selectors in the array    |
-|                |          | match.                                           |
-+----------------+----------+--------------------------------------------------+
-| ``$all``       | Array    | Matches an array value if it contains all the    |
-|                |          | elements of the argument array.                  |
-+----------------+----------+--------------------------------------------------+
-| ``$elemMatch`` | Selector | Matches and returns all documents that contain an|
-|                |          | array field with at least one element that       |
-|                |          | matches all the specified query criteria.        |
-+----------------+----------+--------------------------------------------------+
-| ``$allMatch``  | Selector | Matches and returns all documents that contain an|
-|                |          | array field with all its elements matching all   |
-|                |          | the specified query criteria.                    |
-+----------------+----------+--------------------------------------------------+
++------------------+----------+--------------------------------------------------+
+| Operator         | Argument | Purpose                                          |
++==================+==========+==================================================+
+| ``$and``         | Array    | Matches if all the selectors in the array match. |
++------------------+----------+--------------------------------------------------+
+| ``$or``          | Array    | Matches if any of the selectors in the array     |
+|                  |          | match. All selectors must use the same index.    |
++------------------+----------+--------------------------------------------------+
+| ``$not``         | Selector | Matches if the given selector does not match.    |
++------------------+----------+--------------------------------------------------+
+| ``$nor``         | Array    | Matches if none of the selectors in the array    |
+|                  |          | match.                                           |
++------------------+----------+--------------------------------------------------+
+| ``$all``         | Array    | Matches an array value if it contains all the    |
+|                  |          | elements of the argument array.                  |
++------------------+----------+--------------------------------------------------+
+| ``$elemMatch``   | Selector | Matches and returns all documents that contain an|
+|                  |          | array field with at least one element that       |
+|                  |          | matches all the specified query criteria.        |
++------------------+----------+--------------------------------------------------+
+| ``$allMatch``    | Selector | Matches and returns all documents that contain an|
+|                  |          | array field with all its elements matching all   |
+|                  |          | the specified query criteria.                    |
++------------------+----------+--------------------------------------------------+
+| ``$keyMapMatch`` | Selector | Matches and returns all documents that contain a |
+|                  |          | map that contains at least one key that matches  |
+|                  |          | all the specified query criteria.                |
++------------------+----------+--------------------------------------------------+
 
 .. _find/and:
 
@@ -610,6 +614,25 @@ is an example used with the primary index (``_all_docs``):
         "genre": {
             "$allMatch": {
                 "$eq": "Horror"
+            }
+        }
+    }
+
+.. _find/keymapmatch:
+
+**The** ``$keyMapMatch`` **operator**
+
+The ``$keyMapMatch`` operator matches and returns all documents that contain a
+map that contains at least one key that matches all the specified query criteria.
+Below is an example used with the primary index (``_all_docs``):
+
+.. code-block:: javascript
+
+    {
+        "_id": { "$gt": null },
+        "cameras": {
+            "$keyMapMatch": {
+                "$eq": "secondary"
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Documentation of a newly proposed Mango query operator that allows to make queries on the keys of a map.

For the example I stayed in the filmography theme, it is supposed to mean : 
match all documents where the `cameras` field, which is a map, has a key equal to `secondary`. 

I don't know if the query examples for the operators are related to a representation of a document somewhere that should also be updated ?

## Related Pull Requests
https://github.com/apache/couchdb/pull/3041

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
