### PR TITLE
fix(api): Fix typo in ddoc/views.rst

### DIFF
--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -632,7 +632,7 @@ Changing the previous example to:
 Raw collation
 -------------
 
-By default CouchDB using `ICU`_ driver for sorting view results. It's possible
+By default CouchDB uses an `ICU`_ driver for sorting view results. It's possible
 use binary collation instead for faster view builds where Unicode collation is
 not important.
 


### PR DESCRIPTION
## Overview

Fixes a small typo in `src/api/ddoc/views.rst`. Not sure if the wording as I've put it is correct, but given that there are probably multiple ICU drivers in existence, I'd wager it is.
