### PR TITLE
Remove misleading sentence about how users can browse their own user docs

### DIFF
--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -300,8 +300,7 @@ several *mandatory* fields, that CouchDB needs for authentication:
 - **type** (*string*): Document type. Constantly has the value ``user``
 
 Additionally, you may specify any custom fields that relate to the target
-user. This is a good place to store user's private information because only the
-target user and CouchDB administrators may browse it.
+user.
 
 .. _org.couchdb.user:
 


### PR DESCRIPTION
This follows up on: https://github.com/apache/couchdb/issues/3084, https://github.com/apache/couchdb/issues/2881 and https://github.com/apache/couchdb/issues/2730#issuecomment-606828007

In my particular case we had the team bug hunting for a few hours because we were sure this particular sentence meant the security behavior of `_users` would have been preserved in Couch 3 when it's not. So maybe it helps others if they aren't given the chance to misunderstand this.

---

As for the edit, I tried rephrasing the sentence but couldn't come up with anything without the potential of misunderstanding, so I think removing it in its entirety is the safest bet. If you have any idea of how to keep it, but make it clearer I'd be happy to learn about it.