### PR TITLE
Fix example request for `POST /{db}/_design_docs` in documentation

### DIFF
--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -279,7 +279,7 @@
 
     .. code-block:: http
 
-        POST /db/_all_docs HTTP/1.1
+        POST /db/_design_docs HTTP/1.1
         Accept: application/json
         Content-Length: 70
         Content-Type: application/json


### PR DESCRIPTION
## Overview

In the CouchDB documentation related to `POST /{db}/_design_docs` there is an issue on the request example.

This PR change `POST /db/_all_docs HTTP/1.1` to `POST /db/_design_docs HTTP/1.1` in the request example.

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
