### PR TITLE
Fix stale options

### DIFF
--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -62,6 +62,8 @@
         from a "stable" set of shards. *Optional*
     :<json string stale: Combination of ``update=false`` and ``stable=true``
         options. Possible options: ``"ok"``, ``false`` (default). *Optional*
+        Note that this parameter is deprecated. Use ``stable`` and ``update`` instead.
+        See :ref:`views/generation` for more details.
     :<json boolean execution_stats: Include
         :ref:`execution statistics <find/statistics>` in the query response.
         *Optional, default: ``false``*

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -76,6 +76,7 @@
       ``update_after`` is equivalent to ``stable=true&update=lazy``.
       The default behavior is equivalent to ``stable=false&update=true``.
       Note that this parameter is deprecated. Use ``stable`` and ``update`` instead.
+      See :ref:`views/generation` for more details.
     :query json startkey: Return records starting with the specified key.
     :query json start_key: Alias for `startkey`.
     :query string startkey_docid: Return records starting with the specified

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -71,10 +71,10 @@
     :query boolean stable: Whether or not the view results should be returned
      from a stable set of shards. Default is ``false``.
     :query string stale: Allow the results from a stale view to be used.
-      Supported values: ``ok``, ``update_after`` and ``false``.
+      Supported values: ``ok`` and ``update_after``.
       ``ok`` is equivalent to ``stable=true&update=false``.
       ``update_after`` is equivalent to ``stable=true&update=lazy``.
-      ``false`` is equivalent to ``stable=false&update=true``.
+      The default behavior is equivalent to ``stable=false&update=true``.
     :query json startkey: Return records starting with the specified key.
     :query json start_key: Alias for `startkey`.
     :query string startkey_docid: Return records starting with the specified

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -75,6 +75,7 @@
       ``ok`` is equivalent to ``stable=true&update=false``.
       ``update_after`` is equivalent to ``stable=true&update=lazy``.
       The default behavior is equivalent to ``stable=false&update=true``.
+      Note that this parameter is deprecated. Use ``stable`` and ``update`` instead.
     :query json startkey: Return records starting with the specified key.
     :query json start_key: Alias for `startkey`.
     :query string startkey_docid: Return records starting with the specified

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -270,7 +270,7 @@ that will occur giving you a quick response and when views will be updated
 which will take a long time. (A 10 million document database took about 10
 minutes to load into CouchDB but about 4 hours to do view generation).
 
-In a cluster, "stable" requests are serviced by a fixed set of shards in order
+In a cluster, "stale" requests are serviced by a fixed set of shards in order
 to present users with consistent results between requests. This comes with an
 availability trade-off - the fixed set of shards might not be the most
 responsive / available within the cluster. If you don't need this kind of

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -254,6 +254,8 @@ For example, something that takes 16 hex digits to represent can be done in
 Views
 =====
 
+.. _views/generation:
+
 Views Generation
 ----------------
 

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -270,7 +270,7 @@ that will occur giving you a quick response and when views will be updated
 which will take a long time. (A 10 million document database took about 10
 minutes to load into CouchDB but about 4 hours to do view generation).
 
-In a cluster, "stale" requests are serviced by a fixed set of shards in order
+In a cluster, "stable" requests are serviced by a fixed set of shards in order
 to present users with consistent results between requests. This comes with an
 availability trade-off - the fixed set of shards might not be the most
 responsive / available within the cluster. If you don't need this kind of


### PR DESCRIPTION
## Overview

The docs for `stale` in views don't match the current behavior of the software.
This PR fixes that issue by removing `false` from the available options from `stale` for views.

Mind that, the "default value" (`false`) for `stale` can no longer be expressed explicitly.

## Testing recommendations
```python3
print(requests.get(f"http://127.0.0.1:15984/{db_name}/_all_docs?stale=false", auth=('adm', 'pass')).json())
```
results in
`{'error': 'query_parse_error', 'reason': 'Invalid value for `stale`.'}`

## GitHub issue number


## Related Pull Requests

This is a follow-up PR for https://github.com/apache/couchdb/pull/3120 .

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
