### PR TITLE
Removed $ from /db/_find in two places

### DIFF
--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -182,7 +182,7 @@ documents whose "director" field has the value "Lars von Trier".
 .. code-block:: javascript
 
     "selector": {
-      "$title": "Live And Let Die"
+      "title": "Live And Let Die"
     },
     "fields": [
       "title",
@@ -468,7 +468,7 @@ The list of combination operators:
       "selector": {
         "$and": [
           {
-            "$title": "Total Recall"
+            "title": "Total Recall"
           },
           {
             "year": {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This PR changes the API documentation for `/db/_find`.

It replaces all keys `$title` with `title`.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

None

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

Accommodates expected behavior from https://github.com/apache/couchdb-documentation/issues/590

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

None

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
