### PR TITLE
Modify the second query of multi-query example.

### DIFF
--- a/src/api/database/bulk-api.rst
+++ b/src/api/database/bulk-api.rst
@@ -373,6 +373,8 @@ Sending multiple queries to a database
                 ]
             },
             {
+                "startkey": "pizza",
+                "endkey": "pizza\uFFFF",
                 "limit": 3,
                 "skip": 2
             }
@@ -394,49 +396,50 @@ Sending multiple queries to a database
     {
         "results" : [
             {
+                "total_rows": 2667,
+                "offset": null,
                 "rows": [
                     {
-                        "id": "meatballs",
+                        "id": "SpaghettiWithMeatballs",
                         "key": "meatballs",
                         "value": 1
                     },
                     {
-                        "id": "spaghetti",
+                        "id": "SpaghettiWithMeatballs",
                         "key": "spaghetti",
                         "value": 1
                     }
                 ],
-                "total_rows": 3
             },
             {
-                "offset" : 2,
+                "total_rows": 2667,
+                "offset" : 1712,
                 "rows" : [
                     {
-                        "id" : "Adukiandorangecasserole-microwave",
-                        "key" : "Aduki and orange casserole - microwave",
+                        "id" : "PizzaMargherita",
+                        "key" : "pizzamargherita",
                         "value" : [
                             null,
-                            "Aduki and orange casserole - microwave"
+                            "Pizza Margherita"
                         ]
                     },
                     {
-                        "id" : "Aioli-garlicmayonnaise",
-                        "key" : "Aioli - garlic mayonnaise",
+                        "id" : "PizzaMarinara",
+                        "key" : "pizzamarinara",
                         "value" : [
                             null,
-                            "Aioli - garlic mayonnaise"
+                            "Pizza Marinara"
                         ]
                     },
                     {
-                        "id" : "Alabamapeanutchicken",
-                        "key" : "Alabama peanut chicken",
+                        "id" : "PizzaRomana",
+                        "key" : "pizzaromana",
                         "value" : [
                             null,
-                            "Alabama peanut chicken"
+                            "Pizza Romana"
                         ]
                     }
-                ],
-                "total_rows" : 2667
+                ]
             }
         ]
     }

--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -182,7 +182,7 @@ documents whose "director" field has the value "Lars von Trier".
 .. code-block:: javascript
 
     "selector": {
-      "$title": "Live And Let Die"
+      "title": "Live And Let Die"
     },
     "fields": [
       "title",
@@ -468,7 +468,7 @@ The list of combination operators:
       "selector": {
         "$and": [
           {
-            "$title": "Total Recall"
+            "title": "Total Recall"
           },
           {
             "year": {

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -843,6 +843,8 @@ Sending multiple queries to a view
                 ]
             },
             {
+                "startkey": "pizza",
+                "endkey": "pizza\uFFFF",
                 "limit": 3,
                 "skip": 2
             }
@@ -864,7 +866,8 @@ Sending multiple queries to a view
     {
         "results" : [
             {
-                "offset": 0,
+                "total_rows": 5264,
+                "offset": null,
                 "rows": [
                     {
                         "id": "SpaghettiWithMeatballs",
@@ -875,44 +878,39 @@ Sending multiple queries to a view
                         "id": "SpaghettiWithMeatballs",
                         "key": "spaghetti",
                         "value": 1
-                    },
-                    {
-                        "id": "SpaghettiWithMeatballs",
-                        "key": "tomato sauce",
-                        "value": 1
                     }
                 ],
-                "total_rows": 3
             },
             {
-                "offset" : 2,
+                "total_rows" : 2667,
+                "offset" : 3417,
                 "rows" : [
                     {
-                        "id" : "Adukiandorangecasserole-microwave",
-                        "key" : "Aduki and orange casserole - microwave",
+                        "id" : "PizzaMargherita",
+                        "key" : "pizzamargherita",
                         "value" : [
                             null,
-                            "Aduki and orange casserole - microwave"
+                            "Pizza Margherita"
                         ]
                     },
                     {
-                        "id" : "Aioli-garlicmayonnaise",
-                        "key" : "Aioli - garlic mayonnaise",
+                        "id" : "PizzaMarinara",
+                        "key" : "pizzamarinara",
                         "value" : [
                             null,
-                            "Aioli - garlic mayonnaise"
+                            "Pizza Marinara"
                         ]
                     },
                     {
-                        "id" : "Alabamapeanutchicken",
-                        "key" : "Alabama peanut chicken",
+                        "id" : "PizzaRomana",
+                        "key" : "pizzaromana",
                         "value" : [
                             null,
-                            "Alabama peanut chicken"
+                            "Pizza Romana"
                         ]
                     }
-                ],
-                "total_rows" : 2667
+
+                ]
             }
         ]
     }

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -882,7 +882,7 @@ Sending multiple queries to a view
                 ],
             },
             {
-                "total_rows" : 2667,
+                "total_rows" : 5264,
                 "offset" : 3417,
                 "rows" : [
                     {

--- a/src/conf.py
+++ b/src/conf.py
@@ -34,7 +34,7 @@ nitpicky = True
 
 # should be over-written using rebar-inherited settings
 version = "3.1"
-release = "3.1.0"
+release = "3.1.1"
 
 project = u"Apache CouchDB\u00ae"
 


### PR DESCRIPTION
## Overview

The second query in the example only included a `skip` and a `limit` parameter. This requires a bit more thinking about the example.
The purpose of this PR is to make it very clear that the second query is a regular query too. 
It also tries to make the result set a bit more consistent.

## Testing recommendations

If the example given could be tested to verify that the output in the example is correct.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

n/a