### PR TITLE
cluster: add a blurb about changing name

### DIFF
--- a/src/setup/cluster.rst
+++ b/src/setup/cluster.rst
@@ -97,6 +97,9 @@ environments.)
     Either properly set up DNS and use fully-qualified domain names, or
     use IP addresses. DNS and FQDNs are preferred.
 
+    Changing the name later is somewhat cumbersome (i.e. moving shards), which
+    is why you will want to set it once and not have to change it.
+
 Open ``etc/vm.args``, on all nodes, and add ``-kernel inet_dist_listen_min 9100``
 and ``-kernel inet_dist_listen_max 9200`` like below:
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Rationale: this is something I would have wanted to see, to avoid having to change -name and reshard a bunch of databases.

As requested in https://github.com/apache/couchdb/pull/3188 I'll open this against the documentation instead.

However, I'm a bit on the fence if I would have looked at clustering docs or scrolled through vm.args, the discoverability aspect of it I mean.

❓ Should the PR be against `master` or against `main`?

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
