### PR TITLE
DISCUSS: replace word master?

### DIFF
--- a/src/intro/consistency.rst
+++ b/src/intro/consistency.rst
@@ -268,7 +268,7 @@ consistency between multiple database servers. If a client makes a write
 operation on server `A`, how do we make sure that this is consistent with
 server `B`, or `C`, or `D`? For relational databases, this is a very complex
 problem with entire books devoted to its solution. You could use
-multi-master, single-master, partitioning, sharding, write-through caches,
+multi-primary, single-primary, partitioning, sharding, write-through caches,
 and all sorts of other complex techniques.
 
 Incremental Replication

--- a/src/intro/index.rst
+++ b/src/intro/index.rst
@@ -22,7 +22,7 @@ JSON documents. Access your documents with your web browser, :ref:`via HTTP
 :ref:`transform <listfun>` your documents with :ref:`JavaScript
 <query-server/js>`. CouchDB works well with modern web and mobile apps.  You
 can distribute your data, efficiently using CouchDB’s :ref:`incremental
-replication <replication/intro>`. CouchDB supports master-master setups with
+replication <replication/intro>`. CouchDB supports primary-primary setups with
 :ref:`automatic conflict <replication/conflicts>` detection.
 
 CouchDB comes with a suite of features, such as on-the-fly document

--- a/src/replication/conflicts.rst
+++ b/src/replication/conflicts.rst
@@ -492,7 +492,7 @@ And here is an example of this in Ruby using the low-level `RestClient`_:
     p read1("test")
 
 An application written this way never has to deal with a ``PUT 409``, and is
-automatically multi-master capable.
+automatically multi-primary capable.
 
 You can see that it's straightforward enough when you know what you're doing.
 It's just that CouchDB doesn't currently provide a convenient HTTP API for

--- a/src/replication/intro.rst
+++ b/src/replication/intro.rst
@@ -85,11 +85,11 @@ When a replication task is initiated on the sending node, it is called *push*
 replication, if it is initiated by the receiving node, it is called *pull*
 replication.
 
-Master - Master replication
+Primary - Primary replication
 ===========================
 
 One replication task will only transfer changes in one direction. To achieve
-master-master replication, it is possible to set up two replication tasks in
+primary-primary replication, it is possible to set up two replication tasks in
 opposite direction. When a change is replicated from database A to B by the
 first task, the second task from B to A will discover that the new change on
 B already exists in A and will wait for further changes.

--- a/src/replication/intro.rst
+++ b/src/replication/intro.rst
@@ -86,7 +86,7 @@ replication, if it is initiated by the receiving node, it is called *pull*
 replication.
 
 Primary - Primary replication
-===========================
+=============================
 
 One replication task will only transfer changes in one direction. To achieve
 primary-primary replication, it is possible to set up two replication tasks in

--- a/src/setup/cluster.rst
+++ b/src/setup/cluster.rst
@@ -305,7 +305,7 @@ After that we can join all the nodes together. Choose one node as the "setup
 coordination node" to run all these commands on.  This "setup coordination
 node" only manages the setup and requires all other nodes to be able to see it
 and vice versa. *It has no special purpose beyond the setup process; CouchDB
-does not have the concept of a "master" node in a cluster.*
+does not have the concept of a "primary" node in a cluster.*
 
 Setup will not work with unavailable nodes. All nodes must be online and properly
 preconfigured before the cluster setup process can begin.

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -122,7 +122,7 @@ specific language governing permissions and limitations under the License.
         </a>
         <br />
         <span class="linkdescr">
-          painless master-master data synchronization
+          painless primary-primary data synchronization
         </span>
       </p>
       <p class="biglink">


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The original PR #597 as been split as if we want to remove the word master warranted a bit more discussion. This PR still replaces it with the word `primary` at least for now, as the PR has been split as-is.

`leader` and and `main` has been suggested as potential alternatives. 



<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
