### PR TITLE
Update for POST /{db}/_index

### DIFF
--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -987,17 +987,15 @@ built using MapReduce Views.
     :code 404: Database not found
     :code 500: Execution error
 
-**Index object format for JSON type indexes**
+    The `Index object` is a JSON object with the following fields:
 
-The index object is a JSON object with the following fields:
+    :json array fields: array of field names following the :ref:`sort
+       syntax <find/sort>`. Nested fields are also allowed, e.g. `"person.name"`.
+    :json json partial_filter_selector: A :ref:`selector <find/selectors>`
+       to apply to documents at indexing time, creating a
+       :ref:`partial index <find/partial_indexes>`. *Optional*
 
--  ``fields``: array of field names following the :ref:`sort
-   syntax <find/sort>`. Nested fields are also allowed, e.g. `"person.name"`.
--  ``partial_filter_selector``: A :ref:`selector <find/selectors>`
-   to apply to documents at indexing time, creating a
-   :ref:`partial index <find/partial_indexes>`. *Optional*
-
-Example of creating a new index for the field called ``foo``:
+    Example of creating a new index for a field called ``foo``:
 
     **Request**:
 

--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -182,7 +182,7 @@ documents whose "director" field has the value "Lars von Trier".
 .. code-block:: javascript
 
     "selector": {
-      "$title": "Live And Let Die"
+      "title": "Live And Let Die"
     },
     "fields": [
       "title",
@@ -468,7 +468,7 @@ The list of combination operators:
       "selector": {
         "$and": [
           {
-            "$title": "Total Recall"
+            "title": "Total Recall"
           },
           {
             "year": {

--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -965,9 +965,6 @@ built using MapReduce Views.
     :query string type: Can be ``"json"`` or ``"text"``. Defaults to json.
         Geospatial indexes will be supported in the future. *Optional*
         Text indexes are supported via a third party library *Optional*
-    :query json partial_filter_selector: A :ref:`selector <find/selectors>`
-        to apply to documents at indexing time, creating a
-        :ref:`partial index <find/partial_indexes>`. *Optional*
     :query boolean partitioned: Determines whether a JSON index is partitioned
         or global. The default value of ``partitioned`` is the ``partitioned``
         property of the database. To create a global index on a
@@ -994,7 +991,7 @@ built using MapReduce Views.
 
 The index object is a JSON object with the following fields:
 
--  ``fields``: array of field names following the :ref:`sort 
+-  ``fields``: array of field names following the :ref:`sort
    syntax <find/sort>`. Nested fields are also allowed, e.g. `"person.name"`.
 -  ``partial_filter_selector``: A :ref:`selector <find/selectors>`
    to apply to documents at indexing time, creating a
@@ -1040,28 +1037,35 @@ The returned JSON confirms the index has been created:
 
 Example index creation using all available query parameters
 
-.. code-block:: javascript
+    **Request**:
+
+    .. code-block:: http
+
+        POST /db/_index HTTP/1.1
+        Content-Type: application/json
+        Content-Length: 396
+        Host: localhost:5984
 
         {
-          "index": {
-            "partial_filter_selector": {
-              "year": {
-                "$gt": 2010
-              },
-              "limit": 10,
-              "skip": 0
+            "index": {
+                "partial_filter_selector": {
+                    "year": {
+                        "$gt": 2010
+                    },
+                    "limit": 10,
+                    "skip": 0
+                },
+                "fields": [
+                    "_id",
+                    "_rev",
+                    "year",
+                    "title"
+                ]
             },
-            "fields": [
-              "_id",
-              "_rev",
-              "year",
-              "title"
-            ]
-          },
-          "ddoc": "example-ddoc",
-          "name": "example-index",
-          "type": "json",
-          "partitioned": false
+            "ddoc": "example-ddoc",
+            "name": "example-index",
+            "type": "json",
+            "partitioned": false
         }
 
 By default, a JSON index will include all documents that have the indexed fields

--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -987,12 +987,18 @@ built using MapReduce Views.
     :code 200: Index created successfully or already exists
     :code 400: Invalid request
     :code 401: Admin permission required
+    :code 404: Database not found
     :code 500: Execution error
 
 **Index object format for JSON type indexes**
 
-The index object is a JSON array of field names following the :ref:`sort
-syntax <find/sort>`. Nested fields are also allowed, e.g. `"person.name"`.
+The index object is a JSON object with the following fields:
+
+-  ``fields``: array of field names following the :ref:`sort 
+   syntax <find/sort>`. Nested fields are also allowed, e.g. `"person.name"`.
+-  ``partial_filter_selector``: A :ref:`selector <find/selectors>`
+   to apply to documents at indexing time, creating a
+   :ref:`partial index <find/partial_indexes>`. *Optional*
 
 Example of creating a new index for the field called ``foo``:
 
@@ -1036,17 +1042,27 @@ Example index creation using all available query parameters
 
 .. code-block:: javascript
 
-    {
-      "selector": {
-        "year": {
-          "$gt": 2010
+        {
+          "index": {
+            "partial_filter_selector": {
+              "year": {
+                "$gt": 2010
+              },
+              "limit": 10,
+              "skip": 0
+            },
+            "fields": [
+              "_id",
+              "_rev",
+              "year",
+              "title"
+            ]
+          },
+          "ddoc": "example-ddoc",
+          "name": "example-index",
+          "type": "json",
+          "partitioned": false
         }
-      },
-      "fields": ["_id", "_rev", "year", "title"],
-      "sort": [{"year": "asc"}],
-      "limit": 10,
-      "skip": 0
-    }
 
 By default, a JSON index will include all documents that have the indexed fields
 present, including those which have null values.

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -1728,7 +1728,7 @@ containing only the requested individual statistic.
 
     :>header Content-Type: :mimetype:`application/json`
     :code 200: Request completed successfully
-    :code 404: The server is unavaialble for requests at this time.
+    :code 404: The server is unavailable for requests at this time.
 
     **Response**:
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -34,7 +34,7 @@ nitpicky = True
 
 # should be over-written using rebar-inherited settings
 version = "3.1"
-release = "3.1.0"
+release = "3.1.1"
 
 project = u"Apache CouchDB\u00ae"
 


### PR DESCRIPTION
## Overview

I am opening this pr in reference to #598 
I've updated the following:

1. added a missing status code (404) 
2. removed `partial_filter_selector` from the query parameters (since it should be a property of the `index` parameter)
3. updated the `index` query parameter (it is no longer a list of strings but a json object)
4. changed the example that showcases the use of all query parameters

## Testing recommendations

Use any tool to send a http request to couchdb using the example given in the pr. I've tested it with Couch DB 3.1.1 and get the following response:
```
result": "exists",
    "id": "_design/example-ddoc",
    "name": "example-index"
}
```
(I've run multiple tests that's why the index already exists)

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
