### PR TITLE
Add missing default headers to responses

### DIFF
--- a/src/api/basics.rst
+++ b/src/api/basics.rst
@@ -231,6 +231,16 @@ response headers important to CouchDB are listed below.
   not know beforehand the size of the data it will send (for example,
   the :ref:`changes feed <changes>`).
 
+- ``X-CouchDB-Body-Time``
+
+  Time spent receiving the request body in milliseconds.
+
+  Available when body content is included in the request.
+
+- ``X-Couch-Request-ID``
+
+  Unique identifier for the request.
+
 .. _chunked transfer encoding:
     https://en.wikipedia.org/wiki/Chunked_transfer_encoding
 


### PR DESCRIPTION
## Overview

CouchDB returns default headers `X-CouchDB-Body-Time` and `X-Couch-Request-ID`. This PR adds docs for them.

## GitHub issue number

https://github.com/apache/couchdb/issues/3261


## Related Pull Requests

https://github.com/apache/couchdb/pull/3279 and https://github.com/apache/couchdb/pull/3281

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
