### PR TITLE
More specific instructions for creating Proxy Authentication token

### DIFF
--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -299,7 +299,14 @@ headers to CouchDB with related requests:
   :config:option:`proxy_use_secret <couch_httpd_auth/proxy_use_secret>`
   is set (which is strongly recommended!), this header provides an HMAC of the
   username to authenticate and the secret token to prevent requests from
-  untrusted sources.
+  untrusted sources. (Use the SHA1 of the username and sign with the secret)
+
+**Creating the token (example with openssl)**:
+
+.. code-block:: sh
+
+    echo -n "foo" | openssl dgst -sha1 -hmac "the_secret"
+    # (stdin)= 22047ebd7c4ec67dfbcbad7213a693249dbfbf86
 
 **Request**:
 
@@ -311,6 +318,7 @@ headers to CouchDB with related requests:
     Content-Type: application/json; charset=utf-8
     X-Auth-CouchDB-Roles: users,blogger
     X-Auth-CouchDB-UserName: foo
+    X-Auth-CouchDB-Token: 22047ebd7c4ec67dfbcbad7213a693249dbfbf86
 
 **Response**:
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The instructions for creating the HMAC token (recommended for proxy authentication) aren't specific enough for developers to actually create a token from a username and secret. This PR clarifies the instructions, adds an example (using openssl) of creating the token and then adds it to the example HTTP request.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
- Make sure documentation and syntax highlighting look okay on webpage
- Check that the example openssl command works and produces the same HMAC

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
