### PR TITLE
Update docs regarding users' ability to access the _users database.

### DIFF
--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -453,52 +453,6 @@ document, add a special field to it, and post it back.
     There is no password confirmation for API request: you should implement it
     in your application layer.
 
-Users Public Information
-------------------------
-
-.. versionadded:: 1.4
-
-Sometimes users *want* to share some information with the world. For instance,
-their contact email to let other users get in touch with them. To solve this
-problem, but still keep sensitive and private information secured, there is
-a special :ref:`configuration <config>` option :config:option:`public_fields
-<couch_httpd_auth/public_fields>`. In this option you may define
-a comma-separated list of users document fields that will be publicly available.
-
-Normally, if you request a user document and you're not an administrator or the
-document's owner, CouchDB will respond with :statuscode:`404`::
-
-    curl http://localhost:5984/_users/org.couchdb.user:robert
-
-.. code-block:: javascript
-
-    {"error":"not_found","reason":"missing"}
-
-This response is constant for both cases when user exists or doesn't exist for
-security reasons.
-
-Now let's share the field ``name``. First, set up the ``public_fields``
-configuration option. Remember, that this action requires administrator
-privileges. The next command will prompt you for user `admin`'s password:
-
-.. code-block:: bash
-
-    curl -X PUT http://localhost:5984/_node/nonode@nohost/_config/couch_httpd_auth/public_fields \
-       -H "Content-Type: application/json" \
-       -d '"name"' \
-       -u admin
-
-What has changed? Let's check Robert's document once again::
-
-    curl http://localhost:5984/_users/org.couchdb.user:robert
-
-.. code-block:: javascript
-
-    {"_id":"org.couchdb.user:robert","_rev":"6-869e2d3cbd8b081f9419f190438ecbe7","name":"robert"}
-
-Good news! Now we may read the field ``name`` in *every user document without
-needing to be an administrator*. Keep in mind, though, not to publish sensitive
-information, especially without user's consent!
 
 Authorization
 =============

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -266,9 +266,15 @@ special security-related constraints applied. Below is a list of how the
 - There is a special design document ``_auth`` that cannot be modified
 - Every document except the `design documents` represent registered
   CouchDB users and belong to them
-- Users may only access (:get:`GET /_users/org.couchdb.user:Jan
-  </{db}/{docid}>`) or modify (:put:`PUT /_users/org.couchdb.user:Jan
-  </{db}/{docid}>`) documents that they own
+- By default, the ``_security`` settings of the ``_users`` database disallow 
+  users from accessing or modifying documents
+
+.. note::
+    
+    Settings can be changed so that users do have access to the ``_users`` database, 
+    but even then they may only access (:get:`GET /_users/org.couchdb.user:Jan
+    </{db}/{docid}>`) or modify (:put:`PUT /_users/org.couchdb.user:Jan
+    </{db}/{docid}>`) documents that they own. This will not be possible in CouchDB 4.0.
 
 These draconian rules are necessary since CouchDB cares about its users'
 personal information and will not disclose it to just anyone. Often, user

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -266,12 +266,12 @@ special security-related constraints applied. Below is a list of how the
 - There is a special design document ``_auth`` that cannot be modified
 - Every document except the `design documents` represent registered
   CouchDB users and belong to them
-- By default, the ``_security`` settings of the ``_users`` database disallow 
+- By default, the ``_security`` settings of the ``_users`` database disallow
   users from accessing or modifying documents
 
 .. note::
-    
-    Settings can be changed so that users do have access to the ``_users`` database, 
+
+    Settings can be changed so that users do have access to the ``_users`` database,
     but even then they may only access (:get:`GET /_users/org.couchdb.user:Jan
     </{db}/{docid}>`) or modify (:put:`PUT /_users/org.couchdb.user:Jan
     </{db}/{docid}>`) documents that they own. This will not be possible in CouchDB 4.0.
@@ -452,7 +452,6 @@ document, add a special field to it, and post it back.
 .. note::
     There is no password confirmation for API request: you should implement it
     in your application layer.
-
 
 Authorization
 =============


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

CouchDB 3.0 no longer allows users to access or modify documents in the `_users` database. This PR changes the Introduction documents to reflect those changes.
- I kept the existing information on 2.0 behaviour (users can access their own documents) but mentioned that it needs a change in settings, and will not be possible in 4.0. This is mentioned in a note so that it is easy to remove for 4.0.
- I removed the Users Public Information section which seems to revolve around a use case where users access documents in `_users`. This change is in a separate commit so it can be easily undone if deemed necessary.
- #513 mentions mandatory fields, but as far as I can tell the documentation on that is not strictly incorrect. The fields related to passwords and salts are generated automatically, and when I tried I couldn't create a user without the roles field. If changes to documentation are needed in this regard, I don't have enough knowledge on the inner workings of CouchDB to make those.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

#513 
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
