### PR TITLE
Add documentation for password_regexp

### DIFF
--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -209,6 +209,25 @@ Authentication Configuration
             [couch_httpd_auth]
             max_iterations = 100000
 
+    .. config:option:: password_regexp :: List of RegExp to check new passwords
+
+        .. versionadded:: 3.2
+
+        A list of
+        `Regular Expressions <https://erlang.org/doc/man/re.html#regexp_syntax>`_
+        to check new/changed passwords.
+        When set, new user passwords must match all RegExp in this list.
+
+        A RegExp can be paired with a `reason text`:
+        ``[{"RegExp", "reason text"}, ...]``.
+        If a RegExp doesn't match, its `reason text` will be appended to the
+        default reason of ``Password does not conform to requirements.`` ::
+
+            [couch_httpd_auth]
+            ; Password must be 10 chars long and have one or more uppercase and
+            ; lowercase char and one or more numbers.
+            password_regexp = [{".{10,}", "Min length is 10 chars."}, "[A-Z]+", "[a-z]+", "\\d+"]
+
     .. config:option:: proxy_use_secret :: Force proxy auth to use secret token
 
         When this option is set to ``true``, the

--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -209,18 +209,18 @@ Authentication Configuration
             [couch_httpd_auth]
             max_iterations = 100000
 
-    .. config:option:: password_regexp :: List of RegExp to check new passwords
+    .. config:option:: password_regexp :: Password regular expressions
 
         .. versionadded:: 3.2
 
         A list of
         `Regular Expressions <https://erlang.org/doc/man/re.html#regexp_syntax>`_
         to check new/changed passwords.
-        When set, new user passwords must match all RegExp in this list.
+        When set, new user passwords must **match** all RegExp in this list.
 
-        A RegExp can be paired with a `reason text`:
+        A RegExp can be paired with a *reason text*:
         ``[{"RegExp", "reason text"}, ...]``.
-        If a RegExp doesn't match, its `reason text` will be appended to the
+        If a RegExp doesn't match, its *reason text* will be appended to the
         default reason of ``Password does not conform to requirements.`` ::
 
             [couch_httpd_auth]


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add documentation for the new `[couch_httpd_auth] password_regexp` config added in apache/couchdb#3483.

## Testing recommendations



## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

apache/couchdb#3483.

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
