### PR TITLE
Fixing erlang command to test connectivity between nodes

### DIFF
--- a/src/setup/cluster.rst
+++ b/src/setup/cluster.rst
@@ -149,7 +149,7 @@ In shell1:
 
 .. code-block:: erlang
 
-    net_kernel:connect_node(car@192.168.0.2).
+    net_kernel:connect_node('car@192.168.0.2').
 
 This will connect to the node called ``car`` on the server called
 ``192.168.0.2``.


### PR DESCRIPTION
## Overview
Following the clustering guide, I found out that running the connectivity erlang command between nodes using an IP address will fail with like

```
(bus@10.20.30.40)1> net_kernel:connect_node(car@10.20.30.50).
* 1: syntax error before: '.'
```

if the `node_name@ip` contains single quotes will work

```
(bus@10.20.30.40)1> net_kernel:connect_node('car@10.20.30.50').
true
```

As the documentation doesn't contain single quotes, I recommend adding them (the actual example fails as it is as it contains an IP)

## Testing recommendations

Follow the clustering guide `2.2.2.2. Confirming connectivity between nodes`
