### PR TITLE
Update docs for new binary location

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -29,7 +29,6 @@ Installation using the Apache CouchDB convenience binary packages
 If you are running one of the following operating systems, the easiest way
 to install CouchDB is to use the convenience binary packages:
 
-* CentOS/RHEL 6
 * CentOS/RHEL 7
 * CentOS/RHEL 8
 * Debian 9 (stretch)
@@ -49,97 +48,36 @@ details are in the `README.Debian`_ file.
 
 .. _README.Debian: https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
 
-Apache CouchDB also provides packages for the SpiderMonkey 1.8.5 JavaScript
-dependency, as the upstream packages for this shared library are starting to
-disappear or become unreliable.
+For distributions lacking a compatible SpiderMonkey library, Apache CouchDB
+also provides packages for the 1.8.5 version.
 
 Enabling the Apache CouchDB package repository
 ----------------------------------------------
 
 .. highlight:: sh
 
-**Debian 9 (stretch)**: Run the following commands::
+**Debian or Ubuntu**: Run the following commands::
 
-    $ sudo apt-get install -y apt-transport-https gnupg ca-certificates
-    $ echo "deb https://apache.bintray.com/couchdb-deb stretch main" \
-        | sudo tee /etc/apt/sources.list.d/couchdb.list
+    sudo apt update && sudo apt install -y curl apt-transport-https gnupg
+    curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
+    source /etc/os-release
+    echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
+        | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
-**Debian 10 (buster)**: Run the following commands::
+**RedHat or CentOS**: Run the following commands::
 
-    $ sudo apt-get install -y gnupg ca-certificates
-    $ echo "deb https://apache.bintray.com/couchdb-deb buster main" \
-        | sudo tee /etc/apt/sources.list.d/couchdb.list
-
-**Ubuntu 16.04 (Xenial)**: Run the following commands::
-
-    $ sudo apt-get install -y apt-transport-https gnupg ca-certificates
-    $ echo "deb https://apache.bintray.com/couchdb-deb xenial main" \
-        | sudo tee /etc/apt/sources.list.d/couchdb.list
-
-**Ubuntu 18.04 (Bionic)**: Run the following commands::
-
-    $ sudo apt-get install -y gnupg ca-certificates
-    $ echo "deb https://apache.bintray.com/couchdb-deb bionic main" \
-        | sudo tee /etc/apt/sources.list.d/couchdb.list
-
-**Ubuntu 20.04 (Focal)**: Run the following commands::
-
-    $ sudo apt-get install -y gnupg ca-certificates
-    $ echo "deb https://apache.bintray.com/couchdb-deb focal main" \
-        | sudo tee /etc/apt/sources.list.d/couchdb.list
-
-.. highlight:: ini
-
-**CentOS**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
-
-    [bintray--apache-couchdb-rpm]
-    name=bintray--apache-couchdb-rpm
-    baseurl=http://apache.bintray.com/couchdb-rpm/el$releasever/$basearch/
-    gpgcheck=0
-    repo_gpgcheck=0
-    enabled=1
-
-**RedHat 6**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
-
-    [bintray--apache-couchdb-rpm]
-    name=bintray--apache-couchdb-rpm
-    baseurl=http://apache.bintray.com/couchdb-rpm/el6/$basearch/
-    gpgcheck=0
-    repo_gpgcheck=0
-    enabled=1
-
-**RedHat 7**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
-
-    [bintray--apache-couchdb-rpm]
-    name=bintray--apache-couchdb-rpm
-    baseurl=http://apache.bintray.com/couchdb-rpm/el7/$basearch/
-    gpgcheck=0
-    repo_gpgcheck=0
-    enabled=1
-
-**RedHat 8**: Place the following text into ``/etc/yum.repos.d/bintray-apache-couchdb-rpm.repo``::
-
-    [bintray--apache-couchdb-rpm]
-    name=bintray--apache-couchdb-rpm
-    baseurl=http://apache.bintray.com/couchdb-rpm/el8/$basearch/
-    gpgcheck=0
-    repo_gpgcheck=0
-    enabled=1
+    sudo yum install -y yum-utils
+    sudo yum-config-manager --add-repo https://couchdb.apache.org/repo/couchdb.repo
 
 Installing the Apache CouchDB packages
 --------------------------------------
 
 .. highlight:: sh
 
-**Debian/Ubuntu**: First, install the CouchDB repository key::
+**Debian or Ubuntu**: Run the following commands::
 
-    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
-      8756C4F765C9AC3CB6B85D62379CE192D401AB61
-
-Then update the repository cache and install the package::
-
-    $ sudo apt update
-    $ sudo apt install -y couchdb
+    sudo apt update
+    sudo apt install -y couchdb
 
 Debian/Ubuntu installs from binaries can be pre-configured for single node or
 clustered installations. For clusters, multiple nodes will still need to be
@@ -148,7 +86,7 @@ joined together and configured consistently across all machines; **follow the**
 
 **RedHat/CentOS**: Run the command::
 
-    $ sudo yum -y install epel-release && sudo yum -y install couchdb
+    sudo yum install -y couchdb
 
 Once installed, :ref:`create an admin user<config/admins>` by hand before
 starting CouchDB, if your installer didn't do this for you already.
@@ -158,7 +96,25 @@ You can now start the service.
 **Your installation is not complete. Be sure to complete the**
 :ref:`Setup <setup>` **steps for a single node or clustered installation.**
 
-Relax! CouchDB is installed and running.
+**Relax!** CouchDB is installed and running.
+
+GPG keys used for signing the CouchDB repositories
+--------------------------------------------------
+
+As of 2021.04.25, the *repository* signing key for both types of supported packages
+is::
+
+    pub   rsa8192 2015-01-19 [SC]
+          390EF70BB1EA12B2773962950EE62FB37A00258D
+    uid           The Apache Software Foundation (Package repository signing key) <root@apache.org>
+
+As of 2021.04.25, the *package* signing key (only used for ``rpm`` packages) is::
+
+    pub   rsa4096 2017-07-28 [SC] [expires: 2022-07-27]
+          2EC788AE3F239FA13E82D215CDE711289384AE37
+    uid           Joan Touzet (Apache Code Signing Key) <wohali@apache.org>
+
+Both are available from most popular GPG key servers.
 
 Installation from source
 ========================


### PR DESCRIPTION
## Overview

Bintray is deprecated and going away at the end of April. We now have new repos at JFrog Artifactory. 

This updates the documentation with pointers to the new repos, and an improved installation workflow.

## Testing recommendations

Try installing packages on any of the supported operating systems:

* CentOS / RHEL 7 or 8
* Debian stretch or bsuter
* Ubuntu 16.04 (xenial), 18.04 (bionic), 20.04 (focal)

You could test this easily in docker with any of:

```
docker run -it centos:7
docker run -it centos:8
docker run -it debian:stretch
docker run -it debian:buster
docker run -it debian:stretch
docker run -it ubuntu:xenial
docker run -it ubuntu:bionic
docker run -it ubuntu:focal
```

and just follow the directions in the PR revised text.

## GitHub issue number

Fixes apache/couchdb#3478

## Related Pull Requests

I will need to make this change to our stable tag as well, which will require a fork and a tag move. Please +1 that action along with this. Once I do that, this page:

    https://docs.couchdb.org/en/stable/install/unix.html

will also get updated.