### PR TITLE
Clarified default behavior of authorization to databases

### DIFF
--- a/src/api/database/security.rst
+++ b/src/api/database/security.rst
@@ -49,10 +49,13 @@
     has no admins or members.
 
     Having no admins, only server admins (with the reserved ``_admin`` role)
-    are able to update design document and make other admin level changes.
+    are able to update design documents and make other admin level changes.
 
-    Having no members, any user can write regular documents (any non-design
+    Having no members and roles, any user can write regular documents (any non-design
     document) and read documents from the database.
+    
+    Since CouchDB 3.x newly created databases have by default the _admin role
+    to prevent unintentional access.
 
     If there are any member names or roles defined for a database, then only
     authenticated users having a matching name or role are allowed to read

--- a/src/api/database/security.rst
+++ b/src/api/database/security.rst
@@ -53,7 +53,7 @@
 
     Having no members or roles, any user can write regular documents (any
     non-design document) and read documents from the database.
-    
+
     Since CouchDB 3.x newly created databases have by default the _admin role
     to prevent unintentional access.
 

--- a/src/api/database/security.rst
+++ b/src/api/database/security.rst
@@ -51,8 +51,8 @@
     Having no admins, only server admins (with the reserved ``_admin`` role)
     are able to update design documents and make other admin level changes.
 
-    Having no members and roles, any user can write regular documents (any non-design
-    document) and read documents from the database.
+    Having no members or roles, any user can write regular documents (any
+    non-design document) and read documents from the database.
     
     Since CouchDB 3.x newly created databases have by default the _admin role
     to prevent unintentional access.


### PR DESCRIPTION
Just clarified the section a little with information from slack

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
