### PR TITLE
Update supported spidermonkey versions

### DIFF
--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -137,7 +137,7 @@ You should have the following installed:
 * `Erlang OTP (19.x, 20.x >= 21.3.8.5, 21.x >= 21.2.3, 22.x >= 22.0.5) <http://erlang.org/>`_
 * `ICU                          <http://icu-project.org/>`_
 * `OpenSSL                      <http://www.openssl.org/>`_
-* `Mozilla SpiderMonkey (1.8.5) <https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey>`_
+* `Mozilla SpiderMonkey (1.8.5, 60, 68, 78) <https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey>`_
 * `GNU Make                     <http://www.gnu.org/software/make/>`_
 * `GNU Compiler Collection      <http://gcc.gnu.org/>`_
 * `libcurl                      <http://curl.haxx.se/libcurl/>`_


### PR DESCRIPTION
## Overview

The installation guide made it seem like you still need mozjs 1.8.5 to build, but newer versions are now supported

## Testing recommendations

Render docs

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
