### PR TITLE
Move some config options from [httpd] to [chttpd], from [couch_httpd_auth] to [chttpd_auth]

### DIFF
--- a/src/api/basics.rst
+++ b/src/api/basics.rst
@@ -578,7 +578,7 @@ specific request types are provided in the corresponding API call reference.
 
   A document exceeds the configured :config:option:`couchdb/max_document_size`
   value or the entire request exceeds the
-  :config:option:`httpd/max_http_request_size` value.
+  :config:option:`chttpd/max_http_request_size` value.
 
 - ``415 - Unsupported Media Type``
 

--- a/src/api/database/changes.rst
+++ b/src/api/database/changes.rst
@@ -95,7 +95,7 @@
         before the response is sent, even if there are no results.
         Only applicable for :ref:`longpoll <changes/longpoll>` or
         :ref:`continuous <changes/continuous>` feeds.
-        Default value is specified by :config:option:`httpd/changes_timeout`
+        Default value is specified by :config:option:`chttpd/changes_timeout`
         configuration option. Note that ``60000`` value is also the default
         maximum timeout to prevent undetected dead connections.
     :query string view: Allows to use view functions as filters. Documents

--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -74,8 +74,8 @@ client can use for the next few requests to CouchDB. Tokens are valid until
 a timeout. When CouchDB sees a valid token in a subsequent request, it will
 authenticate the user by this token without requesting the password again. By
 default, cookies are valid for 10 minutes, but it's :config:option:`adjustable
-<couch_httpd_auth/timeout>`. Also it's possible to make cookies
-:config:option:`persistent <couch_httpd_auth/allow_persistent_cookies>`.
+<chttpd_auth/timeout>`. Also it's possible to make cookies
+:config:option:`persistent <chttpd_auth/allow_persistent_cookies>`.
 
 To obtain the first token and thus authenticate a user for the first time, the
 `username` and `password` must be sent to the :ref:`_session API
@@ -290,13 +290,13 @@ This authentication method allows creation of a :ref:`userctx_object` for
 remotely authenticated user. By default, the client just needs to pass specific
 headers to CouchDB with related requests:
 
-- :config:option:`X-Auth-CouchDB-UserName <couch_httpd_auth/x_auth_username>`:
+- :config:option:`X-Auth-CouchDB-UserName <chttpd_auth/x_auth_username>`:
   username;
-- :config:option:`X-Auth-CouchDB-Roles <couch_httpd_auth/x_auth_roles>`:
+- :config:option:`X-Auth-CouchDB-Roles <chttpd_auth/x_auth_roles>`:
   comma-separated (``,``) list of user roles;
-- :config:option:`X-Auth-CouchDB-Token <couch_httpd_auth/x_auth_token>`:
+- :config:option:`X-Auth-CouchDB-Token <chttpd_auth/x_auth_token>`:
   authentication token. When
-  :config:option:`proxy_use_secret <couch_httpd_auth/proxy_use_secret>`
+  :config:option:`proxy_use_secret <chttpd_auth/proxy_use_secret>`
   is set (which is strongly recommended!), this header provides an HMAC of the
   username to authenticate and the secret token to prevent requests from
   untrusted sources. (Use the SHA1 of the username and sign with the secret)

--- a/src/api/server/configuration.rst
+++ b/src/api/server/configuration.rst
@@ -78,20 +78,20 @@ interact with the local node's configuration.
                 "view_index_dir": "/var/lib/couchdb"
             },
             "chttpd": {
+                "allow_jsonp": "false",
                 "backlog": "512",
                 "bind_address": "0.0.0.0",
                 "port": "5984",
                 "require_valid_user": "false",
                 "socket_options": "[{sndbuf, 262144}, {nodelay, true}]",
-                "server_options": "[{recbuf, undefined}]"
+                "server_options": "[{recbuf, undefined}]",
+                "secure_rewrites": "true"
             },
             "httpd": {
-                "allow_jsonp": "false",
                 "authentication_handlers": "{couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}",
                 "bind_address": "192.168.0.2",
                 "max_connections": "2048",
                 "port": "5984",
-                "secure_rewrites": "true"
             },
             "log": {
                 "writer": "file",
@@ -155,13 +155,10 @@ interact with the local node's configuration.
         Server: CouchDB (Erlang/OTP)
 
         {
-            "allow_jsonp": "false",
             "authentication_handlers": "{couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}",
             "bind_address": "127.0.0.1",
             "default_handler": "{couch_httpd_db, handle_request}",
-            "enable_cors": "false",
-            "port": "5984",
-            "secure_rewrites": "true"
+            "port": "5984"
         }
 
 .. _api/config/section/key:

--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -106,7 +106,7 @@ Server Administrators
         1.4 `PBKDF2` server-side hashed salted password support added, now as a
         synchronous call for the ``_config/admins`` API.
 
-.. _config/couch_httpd_auth:
+.. _config/chttpd_auth:
 
 Authentication Configuration
 ============================
@@ -130,176 +130,210 @@ Authentication Configuration
             [chttpd]
             require_valid_user_except_for_up = false
 
-.. config:section:: couch_httpd_auth :: Authentication Configuration
+.. config:section:: chttpd_auth :: Authentication Configuration
+
+    .. versionchanged:: 3.2 These options were moved to [chttpd_auth] section:
+                        `authentication_redirect`, `require_valid_user`, `timeout`,
+                        `auth_cache_size`, `allow_persistent_cookies`, `iterations`,
+                        `min_iterations`, `max_iterations`, `secret`, `users_db_public`,
+                        `x_auth_roles`, `x_auth_token`, `x_auth_username`,
+                        `cookie_domain`, `same_site`.
 
     .. config:option:: allow_persistent_cookies :: Persistent cookies
+
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         When set to ``true``, CouchDB will set the Max-Age and Expires attributes
         on the cookie, which causes user agents (like browsers) to preserve the cookie
         over restarts. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             allow_persistent_cookies = true
 
     .. config:option:: cookie_domain :: Cookie Domain
 
         .. versionadded:: 2.1.1
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         Configures the ``domain`` attribute of the ``AuthSession`` cookie. By default the
         ``domain`` attribute is empty, resulting in the cookie being set on CouchDB's domain. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             cookie_domain = example.com
 
     .. config:option:: same_site :: SameSite
 
         .. versionadded:: 3.0.0
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         When this option is set to a non-empty value, a ``SameSite`` attribute is added to
         the ``AuthSession`` cookie. Valid values are ``none``, ``lax`` or ``strict``.::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             same_site = strict
 
     .. config:option:: auth_cache_size :: Authentication cache
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         Number of :ref:`userctx_object` to cache in memory, to reduce disk
         lookups. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             auth_cache_size = 50
 
     .. config:option:: authentication_redirect :: Default redirect for authentication requests
+
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         Specifies the location for redirection on successful authentication if
         a ``text/html`` response is accepted by the client (via an ``Accept``
         header). ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             authentication_redirect = /_utils/session.html
 
     .. config:option:: iterations :: PBKDF2 iterations count
 
         .. versionadded:: 1.3
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         The number of iterations for password hashing by the PBKDF2 algorithm.
         A higher  number provides better hash durability, but comes at a cost
         in performance for each request that requires authentication. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             iterations = 10000
 
     .. config:option:: min_iterations :: Minimum PBKDF2 iterations count
 
         .. versionadded:: 1.6
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         The minimum number of iterations allowed for passwords hashed by the
         PBKDF2 algorithm. Any user with fewer iterations is forbidden. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             min_iterations = 100
 
     .. config:option:: max_iterations :: Maximum PBKDF2 iterations count
 
         .. versionadded:: 1.6
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         The maximum number of iterations allowed for passwords hashed by the
         PBKDF2 algorithm. Any user with greater iterations is forbidden. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             max_iterations = 100000
 
     .. config:option:: proxy_use_secret :: Force proxy auth to use secret token
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         When this option is set to ``true``, the
-        :option:`couch_httpd_auth/secret` option is required for
+        :option:`chttpd_auth/secret` option is required for
         :ref:`api/auth/proxy`. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             proxy_use_secret = false
 
     .. config:option:: public_fields :: User documents public fields
 
         .. versionadded:: 1.4
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         A comma-separated list of field names in user documents (in
         :option:`couchdb/users_db_suffix`) that can be read by any
         user. If unset or not specified, authenticated users can only retrieve
         their own document. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             public_fields = first_name, last_name, contacts, url
 
         .. note::
             Using the ``public_fields`` allowlist for user document properties
-            requires setting the :option:`couch_httpd_auth/users_db_public`
+            requires setting the :option:`chttpd_auth/users_db_public`
             option to ``true`` (the latter option has no other purpose)::
 
-                [couch_httpd_auth]
+                [chttpd_auth]
                 users_db_public = true
 
     .. config:option:: require_valid_user :: Force user authentication
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         When this option is set to ``true``, no requests are allowed from
         anonymous users. Everyone must be authenticated. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             require_valid_user = false
 
     .. config:option:: secret :: Authentication secret token
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         The secret token is used for :ref:`api/auth/proxy` and for :ref:`api/auth/cookie`. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             secret = 92de07df7e7a3fe14808cef90a7cc0d91
 
     .. config:option:: timeout :: Session timeout
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         Number of seconds since the last request before sessions will be
         expired. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             timeout = 600
 
     .. config:option:: users_db_public :: Publish user documents
 
         .. versionadded:: 1.4
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         Allow all users to view user documents. By default, only admins may
         browse all users documents, while users may browse only their own
         document. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             users_db_public = false
 
     .. config:option:: x_auth_roles :: Proxy Auth roles header
+
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
 
         The HTTP header name (``X-Auth-CouchDB-Roles`` by default) that
         contains the list of a user's roles, separated by a comma. Used for
         :ref:`api/auth/proxy`. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             x_auth_roles = X-Auth-CouchDB-Roles
 
     .. config:option:: x_auth_token :: Proxy Auth token header
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         The HTTP header name (``X-Auth-CouchDB-Token`` by default) containing
         the token used to authenticate the authorization. This token is an
-        `HMAC-SHA1` created from the :option:`couch_httpd_auth/secret` and
-        :option:`couch_httpd_auth/x_auth_username`. The secret key should be
+        `HMAC-SHA1` created from the :option:`chttpd_auth/secret` and
+        :option:`chttpd_auth/x_auth_username`. The secret key should be
         the same on the client and the CouchDB node. This token is optional if
-        the value of the :option:`couch_httpd_auth/proxy_use_secret` option is
+        the value of the :option:`chttpd_auth/proxy_use_secret` option is
         not ``true``. Used for :ref:`api/auth/proxy`. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             x_auth_token = X-Auth-CouchDB-Token
 
     .. config:option:: x_auth_username :: Proxy Auth username header
 
+        .. versionchanged:: 3.2 moved from [couch_httpd_auth] to [chttpd_auth] section
+
         The HTTP header name (``X-Auth-CouchDB-UserName`` by default)
         containing the username. Used for :ref:`api/auth/proxy`. ::
 
-            [couch_httpd_auth]
+            [chttpd_auth]
             x_auth_username = X-Auth-CouchDB-UserName
 
 .. config:section:: jwt_auth :: JWT Authentication

--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -146,7 +146,7 @@ Base CouchDB Options
            http request body sizes. For individual document updates via `PUT`
            that approximation was close enough, however that is not the case
            for `_bulk_docs` endpoint. After 2.1.0 a separate configuration
-           parameter was defined: :config:option:`httpd/max_http_request_size`,
+           parameter was defined: :config:option:`chttpd/max_http_request_size`,
            which can be used to limit maximum http request sizes. After upgrade,
            it is advisable to review those settings and adjust them accordingly.
 

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -24,10 +24,10 @@ HTTP Server Options
 
 .. config:section:: chttpd :: Clustered HTTP Server Options
 
-.. note::
-    In CouchDB 2.x and 3.x, the `chttpd` section refers to the standard, clustered
-    port. All use of CouchDB, aside from a few specific maintenance tasks as
-    described in this documentation, should be performed over this port.
+    .. note::
+        In CouchDB 2.x and 3.x, the `chttpd` section refers to the standard, clustered
+        port. All use of CouchDB, aside from a few specific maintenance tasks as
+        described in this documentation, should be performed over this port.
 
     .. config:option:: bind_address :: HTTP port IP address binding
 
@@ -107,45 +107,138 @@ HTTP Server Options
         enabled on a per-request basis for any delayed JSON response call by adding
         ``?buffer_response=true`` to the request's parameters.
 
-.. config:section:: httpd :: HTTP Server Options
-
     .. config:option:: allow_jsonp :: Enables JSONP support
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
 
         The ``true`` value of this option enables `JSONP`_ support (it's
         ``false`` by default)::
 
-            [httpd]
+            [chttpd]
             allow_jsonp = false
 
         .. _JSONP: https://en.wikipedia.org/wiki/JSONP
 
     .. config:option:: changes_timeout :: Changes feed timeout
 
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
         Specifies default `timeout` value for :ref:`Changes Feed <changes>` in
         milliseconds (60000 by default)::
 
-            [httpd]
+            [chttpd]
             changes_timeout = 60000 ; 60 seconds
 
     .. config:option:: config_whitelist :: Config options while list
 
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
         Sets the configuration modification whitelist. Only whitelisted values
         may be changed via the :ref:`config API <api/config>`. To allow the
         admin to change this value over HTTP, remember to include
-        ``{httpd,config_whitelist}`` itself. Excluding it from the list would
+        ``{chttpd,config_whitelist}`` itself. Excluding it from the list would
         require editing this file to update the whitelist::
 
-            [httpd]
-            config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
+            [chttpd]
+            config_whitelist = [{chttpd,config_whitelist}, {log,level}, {etc,etc}]
 
     .. config:option:: enable_cors :: Activates CORS
 
         .. versionadded:: 1.3
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
 
         Controls :ref:`CORS <config/cors>` feature::
 
-            [httpd]
+            [chttpd]
             enable_cors = false
+
+    .. config:option:: secure_rewrites :: Default request handler
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
+        This option allow to isolate databases via subdomains::
+
+            [chttpd]
+            secure_rewrites = true
+
+    .. config:option:: x_forwarded_host :: X-Forwarder-Host
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
+        The `x_forwarded_host` header (``X-Forwarded-Host`` by default) is used
+        to forward the original value of the ``Host`` header field in case, for
+        example, if a reverse proxy is rewriting the "Host" header field to
+        some internal host name before forward the request to CouchDB::
+
+            [chttpd]
+            x_forwarded_host = X-Forwarded-Host
+
+        This header has higher priority above ``Host`` one, if only it exists
+        in the request.
+
+    .. config:option:: x_forwarded_proto :: X-Forwarder-Proto
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
+        `x_forwarded_proto` header (``X-Forwarder-Proto`` by default) is used
+        for identifying the originating protocol of an HTTP request, since a
+        reverse proxy may communicate with CouchDB instance using HTTP even if
+        the request to the reverse proxy is HTTPS::
+
+            [chttpd]
+            x_forwarded_proto = X-Forwarded-Proto
+
+    .. config:option:: x_forwarded_ssl :: X-Forwarder-Ssl
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
+        The `x_forwarded_ssl` header (``X-Forwarded-Ssl`` by default) tells
+        CouchDB that it should use the `https` scheme instead of the `http`.
+        Actually, it's a synonym for ``X-Forwarded-Proto: https`` header, but
+        used by some reverse proxies::
+
+            [chttpd]
+            x_forwarded_ssl = X-Forwarded-Ssl
+
+    .. config:option:: enable_xframe_options :: Controls X-Frame-Options header
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
+        Controls :ref:`Enables or disabled <config/xframe_options>` feature::
+
+            [chttpd]
+            enable_xframe_options = false
+
+    .. config:option:: max_http_request_size :: Maximum HTTP request body size
+
+        .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
+
+        Limit the maximum size of the HTTP request body. This setting applies
+        to all requests and it doesn't discriminate between single vs.
+        multi-document operations. So setting it to 1MB would block a
+        `PUT` of a document larger than 1MB, but it might also block a
+        `_bulk_docs` update of 1000 1KB documents, or a multipart/related
+        update of a small document followed by two 512KB attachments. This
+        setting is intended to be used as a protection against maliciously
+        large HTTP requests rather than for limiting maximum document sizes. ::
+
+            [chttpd]
+            max_http_request_size = 4294967296 ; 4 GB
+
+        .. warning::
+           Before version 2.1.0 :config:option:`couchdb/max_document_size` was
+           implemented effectively as ``max_http_request_size``. That is, it
+           checked HTTP request bodies instead of document sizes. After the
+           upgrade, it is advisable to review the usage of these configuration
+           settings.
+
+.. config:section:: httpd :: HTTP Server Options
+
+    .. versionchanged:: 3.2 These options were moved to [chttpd] section:
+                        `allow_jsonp`, `changes_timeout`, `config_whitelist`,
+                        `enable_cors`, `secure_rewrites`, `x_forwarded_host`,
+                        `x_forwarded_proto`, `x_forwarded_ssl`,
+                        `enable_xframe_options`, `max_http_request_size`.
 
     .. config:option:: server_options :: MochiWeb Server Options
 
@@ -161,13 +254,6 @@ HTTP Server Options
 
         .. _Erlang inet: http://www.erlang.org/doc/man/inet.html#setopts-2
 
-    .. config:option:: secure_rewrites :: Default request handler
-
-        This option allow to isolate databases via subdomains::
-
-            [httpd]
-            secure_rewrites = true
-
     .. config:option:: socket_options :: Socket Options
 
         The socket options for the listening socket in CouchDB, as set at the
@@ -181,69 +267,6 @@ HTTP Server Options
         `Erlang inet`_ documentation.
 
         .. _Erlang inet: http://www.erlang.org/doc/man/inet.html#setopts-2
-
-    .. config:option:: x_forwarded_host :: X-Forwarder-Host
-
-        The `x_forwarded_host` header (``X-Forwarded-Host`` by default) is used
-        to forward the original value of the ``Host`` header field in case, for
-        example, if a reverse proxy is rewriting the "Host" header field to
-        some internal host name before forward the request to CouchDB::
-
-            [httpd]
-            x_forwarded_host = X-Forwarded-Host
-
-        This header has higher priority above ``Host`` one, if only it exists
-        in the request.
-
-    .. config:option:: x_forwarded_proto :: X-Forwarder-Proto
-
-        `x_forwarded_proto` header (``X-Forwarder-Proto`` by default) is used
-        for identifying the originating protocol of an HTTP request, since a
-        reverse proxy may communicate with CouchDB instance using HTTP even if
-        the request to the reverse proxy is HTTPS::
-
-            [httpd]
-            x_forwarded_proto = X-Forwarded-Proto
-
-    .. config:option:: x_forwarded_ssl :: X-Forwarder-Ssl
-
-        The `x_forwarded_ssl` header (``X-Forwarded-Ssl`` by default) tells
-        CouchDB that it should use the `https` scheme instead of the `http`.
-        Actually, it's a synonym for ``X-Forwarded-Proto: https`` header, but
-        used by some reverse proxies::
-
-            [httpd]
-            x_forwarded_ssl = X-Forwarded-Ssl
-
-    .. config:option:: enable_xframe_options :: Controls X-Frame-Options header
-
-        Controls :ref:`Enables or disabled <config/xframe_options>` feature::
-
-            [httpd]
-            enable_xframe_options = false
-
-    .. config:option:: max_http_request_size :: Maximum HTTP request body size
-
-        .. versionchanged:: 2.1.0
-
-        Limit the maximum size of the HTTP request body. This setting applies
-        to all requests and it doesn't discriminate between single vs.
-        multi-document operations. So setting it to 1MB would block a
-        `PUT` of a document larger than 1MB, but it might also block a
-        `_bulk_docs` update of 1000 1KB documents, or a multipart/related
-        update of a small document followed by two 512KB attachments. This
-        setting is intended to be used as a protection against maliciously
-        large HTTP requests rather than for limiting maximum document sizes. ::
-
-            [httpd]
-            max_http_request_size = 4294967296 ; 4 GB
-
-        .. warning::
-           Before version 2.1.0 :config:option:`couchdb/max_document_size` was
-           implemented effectively as ``max_http_request_size``. That is, it
-           checked HTTP request bodies instead of document sizes. After the
-           upgrade, it is advisable to review the usage of these configuration
-           settings.
 
 .. _config/ssl:
 
@@ -434,6 +457,7 @@ Cross-Origin Resource Sharing
 .. config:section:: cors :: Cross-Origin Resource Sharing
 
     .. versionadded:: 1.3 added CORS support, see JIRA :issue:`431`
+    .. versionchanged:: 3.2 moved from [httpd] to [chttpd] section
 
     `CORS`, or "Cross-Origin Resource Sharing", allows a resource such as a web
     page running JavaScript inside a browser, to make AJAX requests
@@ -460,10 +484,10 @@ Cross-Origin Resource Sharing
     origins are forbidden from making requests by default, support is available
     for simple requests, preflight requests and per-vhost configuration.
 
-    This section requires :option:`httpd/enable_cors` option have
+    This section requires :option:`chttpd/enable_cors` option have
     ``true`` value::
 
-        [httpd]
+        [chttpd]
         enable_cors = true
 
     .. config:option:: credentials

--- a/src/config/intro.rst
+++ b/src/config/intro.rst
@@ -155,7 +155,7 @@ If you make a typo or the specified IP address is not available from your
 network, CouchDB will be unreachable. The only way to resolve this will be
 to remote into the server, correct the config file, and restart CouchDB. To
 protect yourself against such accidents you may set the
-:option:`httpd/config_whitelist` of permitted configuration parameters for
+:option:`chttpd/config_whitelist` of permitted configuration parameters for
 updates via the HTTP API. Once this option is set, further changes to
 non-whitelisted parameters must take place via the configuration file, and in
 most cases, will also require a server restart before taking effect.

--- a/src/intro/security.rst
+++ b/src/intro/security.rst
@@ -239,8 +239,8 @@ sending the username and password again::
 
 You can keep using this token for 10 minutes by default. After 10 minutes you
 need to authenticate your user again. The token lifetime can be configured
-with the timeout (in seconds) setting in the :ref:`couch_httpd_auth
-<config/couch_httpd_auth>` configuration section.
+with the timeout (in seconds) setting in the :ref:`chttpd_auth
+<config/chttpd_auth>` configuration section.
 
 .. seealso::
     :ref:`Cookie Authentication API Reference <api/auth/cookie>`

--- a/src/setup/cluster.rst
+++ b/src/setup/cluster.rst
@@ -184,7 +184,7 @@ are:
    the cluster when replicating. If this value is not consistent across all nodes
    in the cluster, replications may be forced to rewind the changes feed to zero,
    leading to excessive memory, CPU and network use.
-5. A consistent :config:option:`httpd secret <couch_httpd_auth/secret>`. The secret
+5. A consistent :config:option:`httpd secret <chttpd_auth/secret>`. The secret
    is used in calculating and evaluating cookie and proxy authentication, and should
    be set consistently to avoid unnecessary repeated session cookie requests.
 
@@ -225,7 +225,7 @@ locally on each node; if so, replace ``<server-IP|FQDN>`` below with ``127.0.0.1
     curl -X PUT http://<server-IP|FQDN>:5984/_node/_local/_config/couchdb/uuid -d '"FIRST-UUID-GOES-HERE"'
 
     # Finally, set the shared http secret for cookie creation to the second UUID:
-    curl -X PUT http://<server-IP|FQDN>:5984/_node/_local/_config/couch_httpd_auth/secret -d '"SECOND-UUID-GOES-HERE"'
+    curl -X PUT http://<server-IP|FQDN>:5984/_node/_local/_config/chttpd_auth/secret -d '"SECOND-UUID-GOES-HERE"'
 
 .. _cluster/setup/wizard:
 

--- a/src/whatsnew/1.4.rst
+++ b/src/whatsnew/1.4.rst
@@ -48,7 +48,7 @@ Version 1.4.0
   updates and deletion of databases. :commit:`917d8988`
 * :issue:`1772`: Prevent invalid JSON output when using `all_or_nothing`
   :ref:`of bulk API <api/db/bulk_docs>`. :commit:`dfd39d57`
-* Add a :config:option:`configurable whitelist <couch_httpd_auth/public_fields>`
+* Add a ``configurable whitelist``
   of user document properties. :commit:`8d7ab8b1`
 * :issue:`1852`: Support Last-Event-ID header in EventSource changes feeds.
   :commit:`dfd2199a`

--- a/src/whatsnew/2.1.rst
+++ b/src/whatsnew/2.1.rst
@@ -53,7 +53,7 @@ Upgrade Notes
   ``stale=update_after`` behaviour is equivalent to ``stable=true&update=lazy``.
   The deprecated ``stale`` parameter will be removed in CouchDB 3.0.
 
-* The new :config:option:`httpd/max_http_request_size` configuration parameter
+* The new :``httpd/max_http_request_size`` configuration parameter
   was added. This has the same behavior as the old
   :config:option:`couchdb/max_document_size` configuration parameter, which
   had been unfortunately misnamed, and has now been updated to behave as the

--- a/src/whatsnew/3.2.rst
+++ b/src/whatsnew/3.2.rst
@@ -1,0 +1,52 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. _release/3.2.x:
+
+============
+3.2.x Branch
+============
+
+.. contents::
+    :depth: 1
+    :local:
+
+.. _release/3.2.0:
+
+Version 3.2.0
+=============
+
+Features and Enhancements
+-------------------------
+
+* :ghissue:`3472`, :ghissue:`3473`: Migrate some config options from [httpd]
+  to [chttpd], migrate some from [couch_httpd_auth] to [chttpd_auth], and
+  commented out in the default.ini.
+
+  **Moved config options from [httpd] to [chttpd]:**
+  `allow_jsonp`, `changes_timeout`, `config_whitelist`,
+  `enable_cors`, `secure_rewrites`, `x_forwarded_host`,
+  `x_forwarded_proto`, `x_forwarded_ssl`,
+  `enable_xframe_options`, `max_http_request_size`.
+
+  **Moved config options from [couch_httpd_auth] to [chttpd_auth]:**
+  `authentication_redirect`, `require_valid_user`, `timeout`, `auth_cache_size`,
+  `allow_persistent_cookies`, `iterations`, `min_iterations`, `max_iterations`,
+  `password_scheme`, `proxy_use_secret`, `public_fields`, `secret`,
+  `users_db_public`, `x_auth_roles`, `x_auth_token`, `x_auth_username`,
+  `cookie_domain`, `same_site`
+
+* :ghissue:`3586`: We added a new way of specifying basic auth credentials
+  which can include various characters previously not allowed to be included
+  in the url info part of endpoint urls.
+
+* Thank you for reading.

--- a/src/whatsnew/index.rst
+++ b/src/whatsnew/index.rst
@@ -20,6 +20,7 @@ Release Notes
     :glob:
     :maxdepth: 2
 
+    3.2
     3.1
     3.0
     2.3


### PR DESCRIPTION
## Overview
Modify the documentation about the moved configuration options.
Add 3.2.rst, maybe need more info for it. (Performance, Bugfixes, Features, Enhancements, etc.)

## GitHub issue number
[#3472](https://github.com/apache/couchdb/issues/3472)

## Related Pull Requests
[#3567](https://github.com/apache/couchdb/pull/3567) Move config options from `[httpd]` to `[chttpd]`
[#3577](https://github.com/apache/couchdb/pull/3577) Move config options from `[couch_httpd_auth]` to `[chttpd_auth]`

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
