### PR TITLE
Added a note regarding max_partition_size in index.rst

### DIFF
--- a/src/partitioned-dbs/index.rst
+++ b/src/partitioned-dbs/index.rst
@@ -114,6 +114,12 @@ recommendation is to limit individual partitions to less than ten
 gigabytes (10 GB) of data. Which, for the example of sensor documents,
 equates to roughly 60,000 years of data.
 
+.. note::
+
+    The ``max_partition_size`` under CouchDB dictates the partition limit.
+    The default value for this option is 10GiB but can be changed accordingly.
+    Setting the value for this option to 0 disables the partition limit.
+
 Why use partitions?
 ===================
 


### PR DESCRIPTION
Added a small note in the What is a partition section introducing the reader to the ``max_partition_size`` option. This small note should make it clear that the default limit (and not just a recommendation) for partitions is 10gb but can be changed or disabled accordingly as mentioned in issue #661 