### PR TITLE
Fix escaping of quotes for restructured text

### DIFF
--- a/src/setup/cluster.rst
+++ b/src/setup/cluster.rst
@@ -149,7 +149,7 @@ In shell1:
 
 .. code-block:: erlang
 
-    net_kernel:connect_node('car@192.168.0.2').
+    net_kernel:connect_node(\\'car@192.168.0.2\\').
 
 This will connect to the node called ``car`` on the server called
 ``192.168.0.2``.


### PR DESCRIPTION

## Overview

This fixes erlang command used to connect the two nodes in order to check connectivity.

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged