### PR TITLE
Fix broken links, defunct Travis CI project, and contributing guide branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CouchDB Documentation [![Build Status](https://travis-ci.org/apache/couchdb-documentation.svg?branch=master)](https://travis-ci.org/apache/couchdb-documentation)
+# CouchDB Documentation
 
 This repository contains the Sphinx source for Apache CouchDB's documentation.
 You can view the latest rendered build of this content at:

--- a/src/contributing.rst
+++ b/src/contributing.rst
@@ -141,12 +141,12 @@ leave this for later. For now we'll contribute our change back to CouchDB.
 First, we commit our changes::
 
     $ > git commit -am 'document number encoding'
-    [master a84b2cf] document number encoding
+    [main a84b2cf] document number encoding
     1 file changed, 199 insertions(+)
 
 Then we push the commit to our CouchDB fork::
 
-    $ git push origin master
+    $ git push origin main
 
 Next, we go back to our GitHub page
 https://github.com/username/couchdb-documentation and click the "Pull Request"

--- a/src/install/unix.rst
+++ b/src/install/unix.rst
@@ -46,7 +46,7 @@ node, prompt for the address to which it will bind, and a password for the admin
 Responses to these prompts may be pre-seeded using standard ``debconf`` tools. Further
 details are in the `README.Debian`_ file.
 
-.. _README.Debian: https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
+.. _README.Debian: https://github.com/apache/couchdb-pkg/blob/main/debian/README.Debian
 
 For distributions lacking a compatible SpiderMonkey library, Apache CouchDB
 also provides packages for the 1.8.5 version.

--- a/src/replication/protocol.rst
+++ b/src/replication/protocol.rst
@@ -1894,5 +1894,5 @@ Reference
 .. _MVCC: http://en.wikipedia.org/wiki/Multiversion_concurrency_control
 .. _CouchDB: http://couchdb.apache.org
 .. _Erlang: http://erlang.org
-.. _couch_replicator: https://github.com/apache/couchdb/tree/master/src/couch_replicator
+.. _couch_replicator: https://github.com/apache/couchdb/tree/main/src/couch_replicator
 .. _change notifications: http://guide.couchdb.org/draft/notifications.html


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
- Fix broken couch_replicator link on [2.4. CouchDB Replication Protocol](https://docs.couchdb.org/en/latest/replication/protocol.html)
- Fix broken README.Debian link on [1.1. Installation on Unix-like systems](https://docs.couchdb.org/en/latest/install/unix.html)
- Switch contributing guide to use main instead of master branch
- Remove build state badge in README that points to what appears to be no longer used Travis CI project

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
