### PR TITLE
Use double back-ticks in src/api/server/authn.rst

### DIFF
--- a/src/api/database/changes.rst
+++ b/src/api/database/changes.rst
@@ -36,7 +36,7 @@
                      - :mimetype:`text/event-stream`
                      - :mimetype:`text/plain`
     :<header Last-Event-ID: ID of the last events received by the server on a
-        previous connection. Overrides `since` query parameter.
+        previous connection. Overrides ``since`` query parameter.
     :query array doc_ids: List of document IDs to filter the changes feed as
         valid JSON array. Used with :ref:`_doc_ids <changes/filter/doc_ids>`
         filter. Since `length of URL is limited`_, it is better to use
@@ -75,11 +75,11 @@
         Default is ``false``.
     :query boolean attachments: Include the Base64-encoded content of
         :ref:`attachments <api/doc/attachments>` in the documents that
-        are included if `include_docs` is ``true``. Ignored if `include_docs`
+        are included if ``include_docs`` is ``true``. Ignored if ``include_docs``
         isn't ``true``. Default is ``false``.
     :query boolean att_encoding_info: Include encoding information in attachment
-        stubs if `include_docs` is ``true`` and the particular attachment is
-        compressed. Ignored if `include_docs` isn't ``true``.
+        stubs if ``include_docs`` is ``true`` and the particular attachment is
+        compressed. Ignored if ``include_docs`` isn't ``true``.
         Default is ``false``.
     :query number last-event-id: Alias of `Last-Event-ID` header.
     :query number limit: Limit number of result rows to the specified value
@@ -206,7 +206,7 @@
     unavailable, alternative replicas are selected, and the last known
     checkpoint between them is used. If this happens, you might see changes
     again that you have previously seen. Therefore, an application making use
-    of the `_changes` feed should be ‘idempotent’, that is, able to receive the
+    of the ``_changes`` feed should be ‘idempotent’, that is, able to receive the
     same data multiple times, safely.
 
 .. note::

--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -488,7 +488,7 @@ The list of combination operators:
     }
 
 The ``$and`` operator matches if all the selectors in the array match. Below is
-an example using the primary index (```_all_docs```):
+an example using the primary index (``_all_docs``):
 
 .. code-block:: javascript
 
@@ -648,7 +648,7 @@ Condition Operators
 -------------------
 
 Condition operators are specific to a field, and are used to evaluate the value
-stored in that field. For instance, the basic `$eq` operator matches when the
+stored in that field. For instance, the basic ``$eq`` operator matches when the
 specified field contains a value that is equal to the supplied argument.
 
 .. note::
@@ -890,7 +890,7 @@ Example of selective retrieval of fields from matching documents:
 Pagination
 ==========
 
-Mango queries support pagination via the bookmark field. Every `_find`
+Mango queries support pagination via the bookmark field. Every ``_find``
 response contains a bookmark - a token that CouchDB uses to determine
 where to resume from when subsequent queries are made. To get the next
 set of query results, add the bookmark that was received in the previous
@@ -988,7 +988,7 @@ built using MapReduce Views.
     :>header Transfer-Encoding: ``chunked``
 
     :>json string result: Flag to show whether the index was created or one
-        already exists. Can be `"created"` or `"exists"`.
+        already exists. Can be ``"created"`` or ``"exists"``.
     :>json string id: Id of the design document the index was created in.
     :>json string name: Name of the index created.
 

--- a/src/api/database/misc.rst
+++ b/src/api/database/misc.rst
@@ -100,9 +100,9 @@ leaf revision  `3-c50a32451890a3f1c3e423334cc92745` that will be purged.
 As a result of this purge operation, a document with
 `_id:c6114c65e295552ab1019e2b046b10e` will be completely removed from the
 database's document b+tree, and sequence b+tree. It will not be available
-through `_all_docs` or `_changes` endpoints, as though this document never
-existed. Also as a result of purge operation, the database's `purge_seq` and
-`update_seq` will be increased.
+through ``_all_docs`` or ``_changes`` endpoints, as though this document never
+existed. Also as a result of purge operation, the database's ``purge_seq`` and
+``update_seq`` will be increased.
 
 Notice, how revision `3-b06fcd1c1c9e0ec7c480ee8aa467bf3b` was ignored. Revisions
 that have already been purged and non-leaf revisions are ignored in a purge
@@ -126,8 +126,8 @@ revision tree with only a single branch:
     Document Revision Tree 3
 
 As a result of this purge operation, a new updated version of the document will
-be available in `_all_docs` and `_changes`, creating a new record in `_changes`.
-The database's `purge_seq` and `update_seq` will be increased.
+be available in ``_all_docs`` and ``_changes``, creating a new record in ``_changes``.
+The database's ``purge_seq`` and ``update_seq`` will be increased.
 
 Internal Replication
 ======================

--- a/src/api/ddoc/common.rst
+++ b/src/api/ddoc/common.rst
@@ -58,7 +58,7 @@
       <vdufun>` function source
     * **views** (*object*): :ref:`View functions <viewfun>` definition.
     * **autoupdate** (*boolean*): Indicates whether to automatically build
-      indexes defined in this design document. Default is `true`.
+      indexes defined in this design document. Default is ``true``.
 
     Note, that for ``filters``, ``lists``, ``shows`` and ``updates`` fields
     objects are mapping of function name to string function source code. For

--- a/src/api/ddoc/render.rst
+++ b/src/api/ddoc/render.rst
@@ -26,7 +26,7 @@
 .. http:post:: /{db}/_design/{ddoc}/_show/{func}
     :synopsis: Same as GET method for the related endpoint
 
-    Applies :ref:`show function <showfun>` for `null` document.
+    Applies :ref:`show function <showfun>` for ``null`` document.
 
     The request and response parameters are depended upon function
     implementation.

--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -29,29 +29,29 @@
                      - :mimetype:`text/plain`
 
     :query boolean conflicts: Include `conflicts` information in response.
-      Ignored if `include_docs` isn't ``true``. Default is ``false``.
+      Ignored if ``include_docs`` isn't ``true``. Default is ``false``.
     :query boolean descending: Return the documents in descending order by key.
       Default is ``false``.
     :query json endkey: Stop returning records when the specified key is
       reached.
-    :query json end_key: Alias for `endkey` param
+    :query json end_key: Alias for ``endkey`` param
     :query string endkey_docid: Stop returning records when the specified
-      document ID is reached. Ignored if `endkey` is not set.
-    :query string end_key_doc_id: Alias for `endkey_docid`.
+      document ID is reached. Ignored if ``endkey`` is not set.
+    :query string end_key_doc_id: Alias for ``endkey_docid``.
     :query boolean group: Group the results using the reduce function to a
-      group or single row. Implies `reduce` is ``true`` and the maximum
-      `group_level`. Default is ``false``.
+      group or single row. Implies ``reduce`` is ``true`` and the maximum
+      ``group_level``. Default is ``false``.
     :query number group_level: Specify the group level to be used. Implies
-      `group` is ``true``.
+      ``group`` is ``true``.
     :query boolean include_docs: Include the associated document with each row.
       Default is ``false``.
     :query boolean attachments: Include the Base64-encoded content of
       :ref:`attachments <api/doc/attachments>` in the documents that are
-      included if `include_docs` is ``true``. Ignored if `include_docs` isn't
+      included if ``include_docs`` is ``true``. Ignored if ``include_docs`` isn't
       ``true``. Default is ``false``.
     :query boolean att_encoding_info: Include encoding information in
-      attachment stubs if `include_docs` is ``true`` and the particular
-      attachment is compressed. Ignored if `include_docs` isn't ``true``.
+      attachment stubs if ``include_docs`` is ``true`` and the particular
+      attachment is compressed. Ignored if ``include_docs`` isn't ``true``.
       Default is ``false``.
     :query boolean inclusive_end: Specifies whether the specified end key
       should be included in the result. Default is ``true``.
@@ -66,7 +66,7 @@
       the results. Default is ``0``.
     :query boolean sorted: Sort returned rows (see :ref:`Sorting Returned Rows
      <api/ddoc/view/sorting>`). Setting this to ``false`` offers a performance
-     boost. The `total_rows` and `offset` fields are not available when this
+     boost. The ``total_rows`` and ``offset`` fields are not available when this
      is set to ``false``. Default is ``true``.
     :query boolean stable: Whether or not the view results should be returned
      from a stable set of shards. Default is ``false``.
@@ -78,15 +78,15 @@
       Note that this parameter is deprecated. Use ``stable`` and ``update`` instead.
       See :ref:`views/generation` for more details.
     :query json startkey: Return records starting with the specified key.
-    :query json start_key: Alias for `startkey`.
+    :query json start_key: Alias for ``startkey``.
     :query string startkey_docid: Return records starting with the specified
       document ID. Ignored if ``startkey`` is not set.
-    :query string start_key_doc_id: Alias for `startkey_docid` param
+    :query string start_key_doc_id: Alias for ``startkey_docid`` param
     :query string update: Whether or not the view in question should be updated
      prior to responding to the user. Supported values: ``true``, ``false``,
      ``lazy``. Default is ``true``.
     :query boolean update_seq: Whether to include in the response an
-      `update_seq` value indicating the sequence id of the database the view
+      ``update_seq`` value indicating the sequence id of the database the view
       reflects. Default is ``false``.
 
     :>header Content-Type: - :mimetype:`application/json`

--- a/src/api/document/attachments.rst
+++ b/src/api/document/attachments.rst
@@ -29,7 +29,7 @@
     :param docid: Document ID
     :param attname: Attachment name
 
-    :<header If-Match: Document's revision. Alternative to `rev` query
+    :<header If-Match: Document's revision. Alternative to ``rev`` query
       parameter
     :<header If-None-Match: Attachment's base64 encoded MD5 binary digest.
       *Optional*
@@ -84,7 +84,7 @@
     :param docid: Document ID
     :param attname: Attachment name
 
-    :<header If-Match: Document's revision. Alternative to `rev` query
+    :<header If-Match: Document's revision. Alternative to ``rev`` query
       parameter
     :<header If-None-Match: Attachment's base64 encoded MD5 binary digest.
       *Optional*
@@ -132,7 +132,7 @@
     :param attname: Attachment name
 
     :<header Content-Type: Attachment MIME type. Default: :mimetype:`application/octet-stream` *Optional*
-    :<header If-Match: Document revision. Alternative to `rev` query parameter
+    :<header If-Match: Document revision. Alternative to ``rev`` query parameter
 
     :query string rev: Document revision. *Optional*
 
@@ -199,7 +199,7 @@
     :param docid: Document ID
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`text/plain`
-    :<header If-Match: Document revision. Alternative to `rev` query parameter
+    :<header If-Match: Document revision. Alternative to ``rev`` query parameter
 
     :query string rev: Document revision. *Required*
     :query string batch: Store changes in :ref:`batch mode

--- a/src/api/document/common.rst
+++ b/src/api/document/common.rst
@@ -93,8 +93,8 @@
       what `rev` was requested. Default is ``false``
     :query boolean local_seq: Includes last update sequence for the
       document. Default is ``false``
-    :query boolean meta: Acts same as specifying all `conflicts`,
-      `deleted_conflicts` and `revs_info` query parameters. Default is
+    :query boolean meta: Acts same as specifying all ``conflicts``,
+      ``deleted_conflicts`` and ``revs_info`` query parameters. Default is
       ``false``
     :query array open_revs: Retrieves documents of specified leaf revisions.
       Additionally, it accepts value as ``all`` to return all leaf revisions.
@@ -177,8 +177,8 @@
     specify the document ID in the request URL.
 
     When updating an existing document, the current document revision must be
-    included in the document (i.e. the request body), as the `rev` query
-    parameter, or in the `If-Match` request header.
+    included in the document (i.e. the request body), as the ``rev`` query
+    parameter, or in the ``If-Match`` request header.
 
     :param db: Database name
     :param docid: Document ID
@@ -191,7 +191,7 @@
       parameter or document key. *Optional*
 
     :query string rev: Document's revision if updating an existing document.
-      Alternative to `If-Match` header or document key. *Optional*
+      Alternative to ``If-Match`` header or document key. *Optional*
     :query string batch: Stores document in :ref:`batch mode
       <api/doc/batch-writes>`. Possible values: ``ok``. *Optional*
     :query boolean new_edits: Prevents insertion of a :ref:`conflicting
@@ -356,7 +356,7 @@
       document ID, and optionally the target document revision, if copying to
       an existing document.  See :ref:`Copying to an Existing Document
       <copy_to_existing_document>`.
-    :<header If-Match: Source document's revision. Alternative to `rev` query
+    :<header If-Match: Source document's revision. Alternative to ``rev`` query
       parameter
     :query string rev: Revision to copy from. *Optional*
     :query string batch: Stores document in :ref:`batch mode

--- a/src/api/local.rst
+++ b/src/api/local.rst
@@ -71,15 +71,15 @@ A list of the available methods and URL paths are provided below:
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`text/plain`
     :query boolean conflicts: Includes `conflicts` information in response.
-      Ignored if `include_docs` isn't ``true``. Default is ``false``.
+      Ignored if ``include_docs`` isn't ``true``. Default is ``false``.
     :query boolean descending: Return the local documents in descending by
       key order. Default is ``false``.
     :query string endkey: Stop returning records when the specified key is
       reached. *Optional*.
-    :query string end_key: Alias for `endkey` param.
+    :query string end_key: Alias for ``endkey`` param.
     :query string endkey_docid: Stop returning records when the specified
         local document ID is reached. *Optional*.
-    :query string end_key_doc_id: Alias for `endkey_docid` param.
+    :query string end_key_doc_id: Alias for ``endkey_docid`` param.
     :query boolean include_docs: Include the full content of the local
       documents in the return. Default is ``false``.
     :query boolean inclusive_end: Specifies whether the specified end key
@@ -94,10 +94,10 @@ A list of the available methods and URL paths are provided below:
       the results. Default is ``0``.
     :query string startkey: Return records starting with the specified key.
       *Optional*.
-    :query string start_key: Alias for `startkey` param.
+    :query string start_key: Alias for ``startkey`` param.
     :query string startkey_docid: Return records starting with the specified
       local document ID. *Optional*.
-    :query string start_key_doc_id: Alias for `startkey_docid` param.
+    :query string start_key_doc_id: Alias for ``startkey_docid`` param.
     :query boolean update_seq: Response includes an ``update_seq`` value
       indicating which sequence id of the underlying database the view
       reflects. Default is ``false``.

--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -184,7 +184,7 @@ To obtain the first token and thus authenticate a user for the first time, the
     :ref:`userctx_object`, the authentication method and database that were
     used, and a list of configured authentication handlers on the server.
 
-    :query boolean basic: Accept ``Basic Auth`` by requesting this resource.
+    :query boolean basic: Accept `Basic Auth` by requesting this resource.
       *Optional*.
     :>json boolean ok: Operation status
     :>json object userCtx: User context for the current user
@@ -282,7 +282,7 @@ Proxy Authentication
         [chttpd]
         authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
-``Proxy authentication`` is very useful in case your application already uses
+`Proxy authentication` is very useful in case your application already uses
 some external authentication service and you don't want to duplicate users and
 their roles in CouchDB.
 

--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -78,7 +78,7 @@ default, cookies are valid for 10 minutes, but it's :config:option:`adjustable
 :config:option:`persistent <chttpd_auth/allow_persistent_cookies>`.
 
 To obtain the first token and thus authenticate a user for the first time, the
-`username` and `password` must be sent to the :ref:`_session API
+``username`` and ``password`` must be sent to the :ref:`_session API
 <api/auth/session>`.
 
 .. _api/auth/session:
@@ -184,7 +184,7 @@ To obtain the first token and thus authenticate a user for the first time, the
     :ref:`userctx_object`, the authentication method and database that were
     used, and a list of configured authentication handlers on the server.
 
-    :query boolean basic: Accept `Basic Auth` by requesting this resource.
+    :query boolean basic: Accept ``Basic Auth`` by requesting this resource.
       *Optional*.
     :>json boolean ok: Operation status
     :>json object userCtx: User context for the current user
@@ -282,7 +282,7 @@ Proxy Authentication
         [chttpd]
         authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
-`Proxy authentication` is very useful in case your application already uses
+``Proxy authentication`` is very useful in case your application already uses
 some external authentication service and you don't want to duplicate users and
 their roles in CouchDB.
 

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -181,13 +181,13 @@
       Default is ``false``.
     :query json endkey: Stop returning databases when the specified key is
       reached.
-    :query json end_key: Alias for `endkey` param
+    :query json end_key: Alias for ``endkey`` param
     :query number limit: Limit the number of the returned databases to the
       specified number.
     :query number skip: Skip this number of databases before starting to return
       the results. Default is ``0``.
     :query json startkey: Return databases starting with the specified key.
-    :query json start_key: Alias for `startkey`.
+    :query json start_key: Alias for ``startkey``.
     :>header Content-Type: - :mimetype:`application/json`
                            - :mimetype:`text/plain; charset=utf-8`
     :code 200: Request completed successfully
@@ -662,7 +662,7 @@
 
 .. note::
     As of CouchDB 2.0.0, fully qualified URLs are required for both the
-    replication `source` and `target` parameters.
+    replication ``source`` and ``target`` parameters.
 
     **Request**
 
@@ -1095,7 +1095,7 @@ error.
     :>json string last_updated: Timestamp of last state update
     :>json object info: Will contain additional information about the
                         state. For errors, this will be an object with
-                        an `"error"` field and string value. For
+                        an ``"error"`` field and string value. For
                         success states, see below.
     :>json number error_count: Consecutive errors count. Indicates how many
                                times in a row this replication has crashed.
@@ -1232,7 +1232,7 @@ error.
     :>json string last_update: Timestamp of last state update
     :>json object info: Will contain additional information about the
                         state. For errors, this will be an object with
-                        an `"error"` field and string value. For
+                        an ``"error"`` field and string value. For
                         success states, see below.
     :>json number error_count: Consecutive errors count. Indicates how many
                                times in a row this replication has crashed.
@@ -1334,7 +1334,7 @@ error.
     :>json string last_update: Timestamp of last state update
     :>json object info: Will contain additional information about the
                         state. For errors, this will be an object with
-                        an `"error"` field and string value. For
+                        an ``"error"`` field and string value. For
                         success states, see below.
     :>json number error_count: Consecutive errors count. Indicates how many
                                times in a row this replication has crashed.

--- a/src/config/compaction.rst
+++ b/src/config/compaction.rst
@@ -127,9 +127,9 @@ channel.
 
     .. config: option:: strict_window
 
-        If set to `true`, any compaction that is still running after the end of
+        If set to ``true``, any compaction that is still running after the end of
         the allowed perio will be suspended, and then resumed during the next
-        window. It defaults to `false`, in which case any running compactions
+        window. It defaults to ``false``, in which case any running compactions
         will be allowed to finish, but no new ones will be started.
 
 There are also several settings that collectively control whether a channel will
@@ -163,5 +163,5 @@ enqueue a file for compaction and how it prioritizes files within its queue:
     .. config:option:: priority
 
         The method used to calculate priority. Can be ratio (calculated as
-        `sizes.file/sizes.active`) or slack (calculated as `sizes.file -
-        sizes.active`). Defaults to ratio.
+        ``sizes.file/sizes.active``) or slack (calculated as ``sizes.file -
+        sizes.active``). Defaults to ratio.

--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -135,7 +135,7 @@ Base CouchDB Options
         code 413 if one or more documents is larger than this configuration
         value.
 
-        In case of `_update` handlers, document size is checked after the
+        In case of ``_update`` handlers, document size is checked after the
         transformation and right before being inserted into the database. ::
 
             [couchdb]
@@ -145,7 +145,7 @@ Base CouchDB Options
            Before version 2.1.0 this setting was implemented by simply checking
            http request body sizes. For individual document updates via `PUT`
            that approximation was close enough, however that is not the case
-           for `_bulk_docs` endpoint. After 2.1.0 a separate configuration
+           for ``_bulk_docs`` endpoint. After 2.1.0 a separate configuration
            parameter was defined: :config:option:`chttpd/max_http_request_size`,
            which can be used to limit maximum http request sizes. After upgrade,
            it is advisable to review those settings and adjust them accordingly.

--- a/src/config/http.rst
+++ b/src/config/http.rst
@@ -36,18 +36,18 @@ HTTP Server Options
             [chttpd]
             bind_address = 127.0.0.1
 
-        To let CouchDB listen any available IP address, use `0.0.0.0`::
+        To let CouchDB listen any available IP address, use ``0.0.0.0``::
 
             [chttpd]
             bind_address = 0.0.0.0
 
-        For IPv6 support you need to set `::1` if you want to let CouchDB
+        For IPv6 support you need to set ``::1`` if you want to let CouchDB
         listen correctly::
 
             [chttpd]
             bind_address = ::1
 
-        or `::` for any available::
+        or ``::`` for any available::
 
             [chttpd]
             bind_address = ::
@@ -59,15 +59,15 @@ HTTP Server Options
             [chttpd]
             port = 5984
 
-        To let CouchDB use any free port, set this option to `0`::
+        To let CouchDB use any free port, set this option to ``0``::
 
             [chttpd]
             port = 0
 
     .. config:option:: prefer_minimal :: Sends minimal set of headers
 
-        If a request has the header `"Prefer": "return=minimal"`, CouchDB
-        will only send the headers that are listed for the `prefer_minimal`
+        If a request has the header ``"Prefer": "return=minimal"``, CouchDB
+        will only send the headers that are listed for the ``prefer_minimal``
         configuration.::
 
             [chttpd]
@@ -217,7 +217,7 @@ HTTP Server Options
         to all requests and it doesn't discriminate between single vs.
         multi-document operations. So setting it to 1MB would block a
         `PUT` of a document larger than 1MB, but it might also block a
-        `_bulk_docs` update of 1000 1KB documents, or a multipart/related
+        ``_bulk_docs`` update of 1000 1KB documents, or a multipart/related
         update of a small document followed by two 512KB attachments. This
         setting is intended to be used as a protection against maliciously
         large HTTP requests rather than for limiting maximum document sizes. ::
@@ -408,17 +408,17 @@ HTTPS (SSL/TLS) Options
 
     .. config:option:: verify_ssl_certificates :: Enable certificate verification
 
-        Set to `true` to validate peer certificates::
+        Set to ``true`` to validate peer certificates::
 
             [ssl]
             verify_ssl_certificates = false
 
     .. config:option:: fail_if_no_peer_cert :: Require presence of client certificate if certificate verification is enabled
 
-        Set to `true` to terminate the TLS/SSL handshake with a
-        `handshake_failure` alert message if the client does not send a
-        certificate. Only used if `verify_ssl_certificates` is `true`. If set
-        to `false` it will only fail if the client sends an invalid certificate
+        Set to ``true`` to terminate the TLS/SSL handshake with a
+        ``handshake_failure`` alert message if the client does not send a
+        certificate. Only used if ``verify_ssl_certificates`` is ``true``. If set
+        to ``false`` it will only fail if the client sends an invalid certificate
         (an empty certificate is considered valid)::
 
             [ssl]
@@ -426,7 +426,7 @@ HTTPS (SSL/TLS) Options
 
     .. config:option:: secure_renegotiate :: Enable secure renegotiation
 
-        Set to `true` to reject renegotiation attempt that does not live up to
+        Set to ``true`` to reject renegotiation attempt that does not live up to
         RFC 5746::
 
             [ssl]
@@ -635,7 +635,7 @@ Virtual Hosts
 
     If your CouchDB is listening on the the default HTTP port (80), or is
     sitting behind a proxy, then you don't need to specify a port number in the
-    `vhost` key.
+    ``vhost`` key.
 
     The first line will rewrite the request to display the content of the
     `example` database. This rule works only if the ``Host`` header is
@@ -654,9 +654,9 @@ variable and use them to create the target path. Some examples::
     :dbname. = /:dbname
     :ddocname.:dbname.example.com = /:dbname/_design/:ddocname/_rewrite
 
-The first rule passes the wildcard as `dbname`. The second one does the same,
+The first rule passes the wildcard as ``dbname``. The second one does the same,
 but uses a variable name. And the third one allows you to use any URL with
-`ddocname` in any database with `dbname`.
+``ddocname`` in any database with ``dbname``.
 
 .. _xframe_options:
 .. _config/xframe_options:
@@ -677,8 +677,8 @@ feature to help against clickjacking.
     ; List of hosts separated by a comma. * means accept all
     ; hosts =
 
-If xframe_options is enabled it will return `X-Frame-Options: DENY` by default.
-If `same_origin` is enabled it will return `X-Frame-Options: SAMEORIGIN`.
-A `X-FRAME-OPTIONS: ALLOW-FROM url` will be returned when `same_origin`
-is false, and the HOST header matches one of the urls in the `hosts` config.
-Otherwise a `X-Frame-Options: DENY` will be returned.
+If xframe_options is enabled it will return ``X-Frame-Options: DENY`` by default.
+If ``same_origin`` is enabled it will return ``X-Frame-Options: SAMEORIGIN``.
+A ``X-FRAME-OPTIONS: ALLOW-FROM url`` will be returned when ``same_origin``
+is false, and the HOST header matches one of the urls in the ``hosts`` config.
+Otherwise a ``X-Frame-Options: DENY`` will be returned.

--- a/src/config/query-servers.rst
+++ b/src/config/query-servers.rst
@@ -38,7 +38,7 @@ Where:
 
 - ``LANGUAGE``: is a programming language which code this query server may
   execute. For instance, there are `PYTHON`, `RUBY`, `CLOJURE` and other
-  query servers in the wild. This value in *lowercase* is also used for `ddoc`
+  query servers in the wild. This value in *lowercase* is also used for ``ddoc``
   field ``language`` to determine which query server processes the functions.
 
   Note, that you may set up multiple query servers for the same programming
@@ -101,8 +101,8 @@ Query Servers Configuration
             [query_server_config]
             os_process_limit = 100
 
-        Setting `os_process_limit` too low can result in starvation of
-        Query Servers, and manifest in `os_process_timeout` errors,
+        Setting ``os_process_limit`` too low can result in starvation of
+        Query Servers, and manifest in ``os_process_timeout`` errors,
         while setting it too high can potentially use too many system
         resources. Production settings are typically 10-20 times the
         default value.

--- a/src/ddocs/views/pagination.rst
+++ b/src/ddocs/views/pagination.rst
@@ -208,10 +208,10 @@ jump to the next 10 rows. We even use skip, but only with the value 1.
 Here is how it works:
 
 - Request `rows_per_page + 1` rows from the view
-- Display `rows_per_page` rows, `store + 1` row as `next_startkey` and
-  `next_startkey_docid`
-- As page information, keep ``startkey`` and `next_startkey`
-- Use the `next_*` values to create the next link, and use the others to
+- Display `rows_per_page` rows, `store + 1` row as ``next_startkey`` and
+  ``next_startkey_docid``
+- As page information, keep ``startkey`` and ``next_startkey``
+- Use the ``next_*`` values to create the next link, and use the others to
   create the previous link
 
 The trick to finding the next page is pretty simple. Instead of requesting 10
@@ -236,8 +236,8 @@ handy. In addition to ``startkey`` and ``limit``, you also use
 ``startkey_docid`` for pagination if, and only if, the extra row you fetch to
 find the next page has the same key as the current ``startkey``.
 
-It is important to note that the `*_docid` parameters only work in addition to
-the `*key` parameters and are only useful to further narrow down the result set
+It is important to note that the ``*_docid`` parameters only work in addition to
+the ``*key`` parameters and are only useful to further narrow down the result set
 of a view for a single key. They do not work on their own (the one exception
 being the built-in :ref:`_all_docs view <api/db/all_docs>`  that already sorts
 by document ID).

--- a/src/intro/api.rst
+++ b/src/intro/api.rst
@@ -619,7 +619,7 @@ Now we can use the database `albums-replica` as a replication target::
 
 .. note::
     As of CouchDB 2.0.0, fully qualified URLs are required for both the
-    replication `source` and `target` parameters.
+    replication ``source`` and ``target`` parameters.
 
 .. note::
     CouchDB supports the option ``"create_target":true`` placed in the JSON

--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -77,16 +77,16 @@ type of algorithm used for prioritization:
     a compaction to be added to the queue. Compactions are prioritised for
     higher values of X.
 
-In both cases, Y is set using the `min_priority` configuration variable. CouchDB
+In both cases, Y is set using the ``min_priority`` configuration variable. CouchDB
 ships with four channels pre-configured: one channel of each type for databases,
 and another one for views.
 
 Channel Configuration
 ---------------------
 
-Channels are defined using `[smoosh.<channel_name>]` configuration blocks, and
-activated by naming the channel in the `db_channels` or `view_channels`
-configuration setting in the `[smoosh]` block. The default configuration is
+Channels are defined using ``[smoosh.<channel_name>]`` configuration blocks, and
+activated by naming the channel in the ``db_channels`` or ``view_channels``
+configuration setting in the ``[smoosh]`` block. The default configuration is
 
 .. code-block:: ini
 
@@ -136,9 +136,9 @@ where `overnight_channel` is the name of the channel you want to configure.
 Note: CouchDB determines time via the UTC (GMT) timezone, so these settings must be
 expressed as UTC (GMT).
 
-The `strict_window` setting will cause the compaction daemon to suspend all
+The ``strict_window`` setting will cause the compaction daemon to suspend all
 active compactions in this channel when exiting the window, and resume them when
-re-entering. If `strict_window` is left at its default of false, the active
+re-entering. If ``strict_window`` is left at its default of false, the active
 compactions will be allowed to complete but no new compactions will be started.
 
 Migration Guide

--- a/src/maintenance/performance.rst
+++ b/src/maintenance/performance.rst
@@ -206,7 +206,7 @@ Connection limit
 
 `MochiWeb`_ handles CouchDB requests.
 The default maximum number of connections is 2048. To change this limit, use the
-`server_options` configuration variable. `max` indicates maximum number of
+``server_options`` configuration variable. ``max`` indicates maximum number of
 connections.
 
 .. code-block:: ini

--- a/src/partitioned-dbs/index.rst
+++ b/src/partitioned-dbs/index.rst
@@ -385,7 +385,7 @@ request like:
 
 Notice that we're not using the ``/dbname/_partition/...`` path for global
 queries. This is because global queries, by definition, do not cover individual
-partitions. Other than having the `"partitioned": false` parameter in the
+partitions. Other than having the ``"partitioned": false`` parameter in the
 design document, global design documents and queries are identical in
 behavior to design documents on non-partitioned databases.
 

--- a/src/replication/intro.rst
+++ b/src/replication/intro.rst
@@ -61,7 +61,7 @@ For transient replications there is no way to query their state when the job is
 finished.
 
 A replication can be stopped by deleting the document, or by updating it with
-its `cancel` property set to `true`.
+its ``cancel`` property set to ``true``.
 
 Replication Procedure
 =====================
@@ -76,7 +76,7 @@ the deletion of documents is represented by a new revision, a document deleted
 on the source will also be deleted on the target.
 
 A replication task will finish once it reaches the end of the changes feed. If
-its `continuous` property is set to true, it will wait for new changes to
+its ``continuous`` property is set to true, it will wait for new changes to
 appear until the task is canceled. Replication tasks also create checkpoint
 documents on the destination to ensure that a restarted task can continue from
 where it stopped, for example after it has crashed.
@@ -113,7 +113,7 @@ that is used to test whether a document should be replicated.
 :ref:`filterfun` can be used in a replication (see
 :ref:`replication-settings`). The replication task evaluates
 the filter function for each document in the changes feed. The document is
-only replicated if the filter returns `true`.
+only replicated if the filter returns ``true``.
 
 .. note::
     Using a selector provides performance benefits when compared with using a


### PR DESCRIPTION
## Overview

As mentioned in #525, I have replaced the single back-ticks to double back-ticks **only in the file `src/api/server/authn.rst`**. I have modified all the instances which was resulting in italicisation. But I noticed that the single back-ticks have been used in a lot of other files.

Please let me know if all the files need to be updated. I'll update the pr with the same.

Thank you in advance!

## GitHub issue number

Fixes #525 

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
