### PR TITLE
Update common.rst to add selector to _replicate

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -602,6 +602,8 @@
       standard ``q`` and ``n`` parameters.
     :<json array doc_ids: Array of document IDs to be synchronized
     :<json string filter: The name of a :ref:`filter function <filterfun>`.
+    :<json json selector: A :ref:`selector <find/selectors>` to filter
+      documents for synchronization.
     :<json string source_proxy: Address of a proxy server through which
       replication from the source should occur (protocol can be "http" or
       "socks5")

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -600,10 +600,14 @@
     :<json object create_target_params: An object that contains parameters
       to be used when creating the target database. Can include the
       standard ``q`` and ``n`` parameters.
-    :<json array doc_ids: Array of document IDs to be synchronized
+    :<json array doc_ids: Array of document IDs to be synchronized.
+      ``doc_ids``, ``filter``, and ``selector`` mutually exclusive.
     :<json string filter: The name of a :ref:`filter function <filterfun>`.
+      ``doc_ids``, ``filter``, and ``selector`` mutually exclusive.
     :<json json selector: A :ref:`selector <find/selectors>` to filter
-      documents for synchronization.
+      documents for synchronization. Has the same behavior as the
+      :ref:`selector objects <selectorobj>` in replication documents.
+      ``doc_ids``, ``filter``, and ``selector`` mutually exclusive.
     :<json string source_proxy: Address of a proxy server through which
       replication from the source should occur (protocol can be "http" or
       "socks5")

--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -601,13 +601,13 @@
       to be used when creating the target database. Can include the
       standard ``q`` and ``n`` parameters.
     :<json array doc_ids: Array of document IDs to be synchronized.
-      ``doc_ids``, ``filter``, and ``selector`` mutually exclusive.
+      ``doc_ids``, ``filter``, and ``selector`` are mutually exclusive.
     :<json string filter: The name of a :ref:`filter function <filterfun>`.
-      ``doc_ids``, ``filter``, and ``selector`` mutually exclusive.
+      ``doc_ids``, ``filter``, and ``selector`` are mutually exclusive.
     :<json json selector: A :ref:`selector <find/selectors>` to filter
       documents for synchronization. Has the same behavior as the
       :ref:`selector objects <selectorobj>` in replication documents.
-      ``doc_ids``, ``filter``, and ``selector`` mutually exclusive.
+      ``doc_ids``, ``filter``, and ``selector`` are mutually exclusive.
     :<json string source_proxy: Address of a proxy server through which
       replication from the source should occur (protocol can be "http" or
       "socks5")


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Document the `selector` field of the `/_replicate` API.

## Testing recommendations

- Create a db `a` and a db `b`.
- Create two document in db `a`.
- Replicate using `/_replicate` from db `a` to `b` with the the `selector` field set, where one doc does not pass.
- Check if only one doc exists in db `b`.

## GitHub issue number

None.
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
