### PR TITLE
add password regexp to 3.2 notes

### DIFF
--- a/src/whatsnew/3.2.rst
+++ b/src/whatsnew/3.2.rst
@@ -113,6 +113,9 @@ Features and Enhancements
   which can include various characters previously not allowed to be included
   in the url info part of endpoint urls.
 
+* :ghissue:`3483`: We added a way of specifying requirements for new user passwords
+  using a list of regexp.
+
 * :ghissue:`3506`, :ghissue:`3416`, :ghissue:`3377`: CouchDB now provides a Prometheus
   compatible endpoint at ``GET /_node/{node-name}/_prometheus``. A configuration option
   allows for scraping via a different port (17986) that does not require authentication,

--- a/src/whatsnew/3.2.rst
+++ b/src/whatsnew/3.2.rst
@@ -114,7 +114,7 @@ Features and Enhancements
   in the url info part of endpoint urls.
 
 * :ghissue:`3483`: We added a way of specifying requirements for new user passwords
-  using a list of regexp.
+  using a list of regular expressions.
 
 * :ghissue:`3506`, :ghissue:`3416`, :ghissue:`3377`: CouchDB now provides a Prometheus
   compatible endpoint at ``GET /_node/{node-name}/_prometheus``. A configuration option


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add `password_regexp` to 3.2 release notes.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
