### PR TITLE
Try to fix readthedocs build errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==1.7.4
-sphinx-rtd-theme==0.4.0
+Sphinx==2.4.4
+sphinx-rtd-theme==1.0.0

--- a/src/conf.py
+++ b/src/conf.py
@@ -118,4 +118,4 @@ github_docs_path = "src"
 
 
 def setup(app):
-    app.add_stylesheet("css/rtd_theme.css")
+    app.add_css_file("css/rtd_theme.css")


### PR DESCRIPTION
Bump sphinx requirements up enough until can build without warnings

This fixes the build https://readthedocs.org/projects/couchdb/builds/15156367/ (compare with https://readthedocs.org/projects/couchdb/builds/15149238/)

Results https://docs.couchdb.org/en/try-to-fix-readthedocs-build/
