### PR TITLE
Update notes for /_dbs_info

### DIFF
--- a/src/api/server/common.rst
+++ b/src/api/server/common.rst
@@ -320,7 +320,9 @@
 .. note::
     The supported number of the specified databases in the list can be limited
     by modifying the `max_db_number_for_dbs_info_req` entry in configuration
-    file. The default limit is 100.
+    file. The default limit is 100. Increasing the limit, while possible, creates
+    load on the server so it is advisable to have more requests with 100 dbs,
+    rather than a few requests with 1000s of dbs at a time.
 
 .. _api/server/cluster_setup:
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Update the Notes section for /_dbs_info to include advise on keeping the db limit to 100.

