### PR TITLE
Fix statement around collation

### DIFF
--- a/src/api/ddoc/views.rst
+++ b/src/api/ddoc/views.rst
@@ -638,9 +638,9 @@ By default CouchDB uses an `ICU`_ driver for sorting view results. It's possible
 use binary collation instead for faster view builds where Unicode collation is
 not important.
 
-To use raw collation add ``"collation": "raw"`` key-value pair to the design
-documents ``options`` object at the root level. After that, views will be
-regenerated and new order applied.
+To use raw collation add ``"options":{"collation":"raw"}``  within the view object of the
+design document. After that, views will be regenerated and new order applied for the
+appropriate view.
 
 .. seealso::
     :ref:`views/collation`


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Meanwhile, the documentation says `collation` should be set to `raw` in the root of the design document's `options` object, actually, it can be set under the view object where `options` will be a sibling of the `map` and `reduce` fields:

```json
{
  "_id":"_design/doc",
  "views": {
     "myview1": {
         "map": "function(...) {}",
         "options": {"collation" : "raw"}
     }
  }
}
```

This is misleading, because design doc root also can have an `options` object, but the children of that object can be  `include_design`, `local_seq`, and `partitioned`.

## Testing recommendations

No

## GitHub issue number

not a significant change

## Related Pull Requests

no

## Checklist

I tested with `make check`.
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
