### PR TITLE
Reformat src/conf.py to conform to latest python black rules

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -36,12 +36,12 @@ nitpicky = True
 version = "3.2"
 release = "3.2.0"
 
-project = u"Apache CouchDB\u00ae"
+project = "Apache CouchDB\u00ae"
 
-copyright = u"%d, %s" % (
+copyright = "%d, %s" % (
     datetime.datetime.now().year,
-    u"Apache Software Foundation. CouchDB\u00ae is a registered trademark of the "
-    + u"Apache Software Foundation",
+    "Apache Software Foundation. CouchDB\u00ae is a registered trademark of the "
+    + "Apache Software Foundation",
 )
 
 primary_domain = "http"


### PR DESCRIPTION
Python black removed Python 2 support so it now flags the `u` prefixed strings.

We picked up python black 22.1:
```
Collecting black
  Downloading black-22.1.0-py3-none-any.whl (160 kB)
```

It removed python 2 support:
 * https://pypi.org/project/black/22.1.0/
 * https://github.com/psf/black/pull/2740

