### PR TITLE
Fix typo (missing literal block mark)

### DIFF
--- a/src/config/couchdb.rst
+++ b/src/config/couchdb.rst
@@ -51,7 +51,7 @@ Base CouchDB Options
         to ``everyone``, anyone can performs reads and writes. When set to
         ``admin_only``, only admins can read and write. When set to
         ``admin_local``, sharded databases can be read and written by anyone
-        but the shards can only be read and written by admins.
+        but the shards can only be read and written by admins. ::
 
             [couchdb]
             default_security = admin_only


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Before this fix, the configuration example of https://docs.couchdb.org/en/3.2.0/config/couchdb.html#couchdb/default_security is not rendered correctly:

![image](https://user-images.githubusercontent.com/8583146/161241200-0b2fdb94-1d13-4bad-89a9-1f956f8f4dfb.png)

Well-rendered example:

![image](https://user-images.githubusercontent.com/8583146/161241494-98bbbed2-1114-440c-b7fa-c4434b47cf2d.png)


