### PR TITLE
Add infos about enable logging over UDP in rsyslog

### DIFF
--- a/src/config/logging.rst
+++ b/src/config/logging.rst
@@ -108,6 +108,10 @@ Logging options
 
     .. config:option:: syslog_host :: Syslog host
 
+        .. note::
+
+            Setting `syslog_host` is mandatory for ``syslog`` to work!
+
         Specifies the syslog host to send logs to. Only used by the
         ``syslog`` :option:`writer <log/writer>`::
 

--- a/src/config/logging.rst
+++ b/src/config/logging.rst
@@ -137,3 +137,13 @@ Logging options
 
             [log]
             syslog_facility = local2
+
+    .. note::
+        CouchDB's ``syslog`` only knows how to use UDP logging. Please ensure that your
+        ``syslog`` server has UDP logging enabled.
+
+        For ``rsyslog`` you can enable the UDP module `imudp` in ``/etc/rsyslog.conf``::
+
+            # provides UDP syslog reception
+            module(load="imudp")
+            input(type="imudp" port="514")


### PR DESCRIPTION
## Overview

Add configuration infos for rsyslog to enable logging to facility

## GitHub issue number

https://github.com/apache/couchdb/issues/3882