### PR TITLE
Fix upgrading instructions references

### DIFF
--- a/src/install/upgrading.rst
+++ b/src/install/upgrading.rst
@@ -69,8 +69,8 @@ If you are running a CouchDB cluster:
 #. Upgrade that CouchDB install in place.
 #. Start CouchDB.
 #. Double-check that the node has re-joined the cluster through the
-   `/_membership <api/server/membership>` endpoint. If your load balancer has
-   health check functionality driven by the `/_up <api/server/up>` endpoint,
+   :ref:`/_membership<api/server/membership>` endpoint. If your load balancer has
+   health check functionality driven by the :ref:`/_up<api/server/up>` endpoint,
    check whether it thinks the node is healthy as well.
 #. Repeat the last 4 steps on the remaining nodes in the cluster.
 #. Relax! You're done.


### PR DESCRIPTION
## Overview

This pull request fixes two internal references in the `1.9.2.2 Cluster upgrades` paragraph

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
