### PR TITLE
Add note to clarify compaction window process

### DIFF
--- a/src/maintenance/compaction.rst
+++ b/src/maintenance/compaction.rst
@@ -141,6 +141,24 @@ active compactions in this channel when exiting the window, and resume them when
 re-entering. If ``strict_window`` is left at its default of false, the active
 compactions will be allowed to complete but no new compactions will be started.
 
+.. note::
+    When a channel is created, a 60s timer is started to check if the channel
+    should be processing any compactions based on the time window defined in your config.
+
+    The channel is set to pending and after 60s it checks if it should be running
+    at all and is set to paused if not.
+    At the end of the check another 60s timer is started to schedule another check.
+
+    Eventually, when in the time window, it starts processing compactions.
+    But since it will continue running a check every 60s running compaction
+    processes will be suspended when exiting the time window and resume them when
+    re-entering the window.
+
+    This means that for the first 60s after exiting the time window,
+    or when a channel is created and you are outside the time window,
+    compactions are run for up to 60s.This is different to the behavior of the
+    old compaction daemon which would cancel the compactions outright.
+
 Migration Guide
 ---------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Some users that we worked with reported compaction running outside of the compaction window configured with `to` `from` `window` options and that was causing confusion and after we looked into the issue and the couchdb code [here](https://github.com/apache/couchdb/blob/3.x/src/smoosh/src/smoosh_channel.erl#L113-L119)
This is just a note to clarify why some compaction process might be found running outside of the defined compaction window 

## Checklist

- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the commit hash once this PR is rebased and merged
<!-- Before opening the PR, consider running `make check` locally for a faster turnaround time -->
