### PR TITLE
Notes _find performance difference between custom indexes and _all_docs

### DIFF
--- a/src/api/database/find.rst
+++ b/src/api/database/find.rst
@@ -20,9 +20,10 @@
     :synopsis: Find documents within a given database
 
     Find documents using a declarative JSON querying syntax.
-    Queries can use the built-in :ref:`_all_docs <api/db/all_docs>` index or
-    custom indexes, specified using the :ref:`_index <api/db/find/index>`
-    endpoint.
+    Queries will use custom indexes, specified using the :ref:`_index <api/db/find/index>`
+    endpoint, if available.
+    Otherwise, they use the built-in :ref:`_all_docs <api/db/all_docs>` index, which
+    can be arbitrarily slow.
 
     :param db: Database name
 


### PR DESCRIPTION
## Overview

The docs currently don't contain much guidance on the performance of _find, which can lead new users down the wrong path.


