### PR TITLE
Documents how to add and remove nodes if the Cluster Setup Wizard isn't enough.

### DIFF
--- a/src/api/server/authn.rst
+++ b/src/api/server/authn.rst
@@ -73,7 +73,7 @@ For cookie authentication (:rfc:`2109`) CouchDB generates a token that the
 client can use for the next few requests to CouchDB. Tokens are valid until
 a timeout. When CouchDB sees a valid token in a subsequent request, it will
 authenticate the user by this token without requesting the password again. By
-default, cookies are valid for 10 minutes, but it's :config:option:`adjustable
+default, cookies are valid for 10 minutes, but it's adjustable via :config:option:`timeout
 <chttpd_auth/timeout>`. Also it's possible to make cookies
 :config:option:`persistent <chttpd_auth/allow_persistent_cookies>`.
 

--- a/src/setup/cluster.rst
+++ b/src/setup/cluster.rst
@@ -362,7 +362,10 @@ Response:
         ]
     }
 
-Ensure the ``all_nodes`` and ``cluster_nodes`` lists match.
+If the cluster is enabled and ``all_nodes`` and ``cluster_nodes`` lists don't match, use curl to add nodes with
+PUT ``/_node/_local/_nodes/couchdb@<reachable-ip-address|fully-qualified-domain-name>``
+and remove nodes with
+DELETE ``/_node/_local/_nodes/couchdb@<reachable-ip-address|fully-qualified-domain-name>``
 
 You CouchDB cluster is now set up.
 


### PR DESCRIPTION
## Overview

Documents how to manually fix cluster management when the automated tool isn't able to do the right thing.

Also changes the name of a link to the name of the setting it references.
