### PR TITLE
Documents when HTTP status 503 Service Unavailable is returned

### DIFF
--- a/src/api/basics.rst
+++ b/src/api/basics.rst
@@ -601,5 +601,5 @@ specific request types are provided in the corresponding API call reference.
 - ``503 - Service Unavailable``
 
   The request can't be serviced at this time, either because the cluster is overloaded,
-  a security migration is underway, or some other reason.
-  The request may be retried as-is, perhaps in a couple minutes.
+  maintenance is underway, or some other reason.
+  The request may be retried without changes, perhaps in a couple of minutes.

--- a/src/api/basics.rst
+++ b/src/api/basics.rst
@@ -597,3 +597,9 @@ specific request types are provided in the corresponding API call reference.
 
   The request was invalid, either because the supplied JSON was invalid, or
   invalid information was supplied as part of the request.
+
+- ``503 - Service Unavailable``
+
+  The request can't be serviced at this time, either because the cluster is overloaded,
+  a security migration is underway, or some other reason.
+  The request may be retried as-is, perhaps in a couple minutes.


### PR DESCRIPTION

## Overview

Documents when HTTP status 503 Service Unavailable is returned, and what the client should do. 

Based on 

```
error_info({error, security_migration_updates_disabled}) ->
    {503, <<"security_migration">>, <<
        "Updates to security docs are disabled during "
        "security migration."
    >>};
error_info(all_workers_died) ->
    {503, <<"service unavailable">>, <<
        "Nodes are unable to service this "
        "request due to overloading or maintenance mode."
    >>};
error_info({service_unavailable, Reason}) ->
    {503, <<"service unavailable">>, Reason};
```

as unearthed by @rnewson 